### PR TITLE
Fix re.split deprecation + harden weekly auto-refresh workflow

### DIFF
--- a/.github/workflows/auto-refresh.yml
+++ b/.github/workflows/auto-refresh.yml
@@ -14,6 +14,13 @@ permissions:
   contents: write
   pull-requests: write
 
+# Never let a scheduled run and a manual dispatch (or two schedules) race on the
+# shared auto-refresh/data branch. Queue them instead of cancelling so a run is
+# never interrupted mid-commit.
+concurrency:
+  group: auto-refresh
+  cancel-in-progress: false
+
 jobs:
   refresh:
     runs-on: ubuntu-latest
@@ -48,6 +55,11 @@ jobs:
           python scripts/render_markdown.py
           python scripts/validate.py
 
+      # Hard gate: the same suite that runs on every PR/push. A regression in the
+      # refreshed data or generated outputs blocks the PR instead of shipping it.
+      - name: Unit tests
+        run: pytest tests -q
+
       - name: Show summary
         run: |
           echo "::group::Diff stats"
@@ -58,10 +70,13 @@ jobs:
           echo "::endgroup::"
 
       - name: Open / update refresh PR
-        uses: peter-evans/create-pull-request@v7
+        # Pinned to a full commit SHA (v7) for supply-chain safety; bump
+        # deliberately rather than tracking a mutable tag.
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           commit-message: "chore(data): weekly auto-refresh"
           branch: auto-refresh/data
+          base: main
           delete-branch: true
           title: "Weekly data refresh"
           labels: data-refresh, automated
@@ -69,6 +84,13 @@ jobs:
             Automated weekly refresh of external sources:
             AIRI Navigator, AIAAIC sheet, OECD AI Incidents Monitor.
 
-            Review the diff before merging — flag any unexpected
-            mass deletions or large taxonomy shifts. Schema validation
-            and the unit tests both ran green in this workflow.
+            On each run this branch is recreated from the current `main`, so the
+            diff is always relative to the latest `main` *at run time*. **Merge
+            promptly** — if commits land on `main` after this PR opens, the open
+            branch goes stale and merging it can revert that newer work. If it
+            has sat open across other merges, close it and re-run this workflow
+            (Actions → "Weekly auto-refresh" → Run workflow) rather than merging.
+
+            Review the diff before merging — flag any unexpected mass deletions
+            or large taxonomy shifts. Schema validation and the full unit-test
+            suite both ran green in this workflow before the PR was opened.

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -329,7 +329,7 @@ def maybe_rewrite_cve_title(entry: dict) -> None:
         return
 
     product = re.split(
-        r"\s+up to\s+|\s+versions? prior to\s+|\s+before\s+|[.,;]", body, 1
+        r"\s+up to\s+|\s+versions? prior to\s+|\s+before\s+|[.,;]", body, maxsplit=1
     )[0].strip()
     if not product or len(product) > 80:
         return


### PR DESCRIPTION
## Summary

Two related maintenance fixes surfaced while reviewing the (now-closed) stale weekly-refresh PR.

### 1. Silence `re.split` DeprecationWarning
`scripts/merge_and_dedupe.py` passed `maxsplit` positionally to `re.split`, which is deprecated in Python 3.13 (the test suite emitted a `DeprecationWarning` from `test_maybe_rewrite_cve_title`). Now passed as a keyword argument. No behavior change.

### 2. Harden `.github/workflows/auto-refresh.yml`
- **Concurrency guard** — a `concurrency` group prevents a scheduled run and a manual `workflow_dispatch` (or two schedules) from racing on the shared `auto-refresh/data` branch. Queued, not cancelled, so a run is never interrupted mid-commit.
- **Unit tests as a hard gate** — the workflow now runs `pytest tests -q` before opening the PR. Previously the PR body claimed "the unit tests ran green" but the workflow never actually invoked pytest — only `validate.py`. A data/output regression now blocks the refresh instead of shipping it.
- **Pinned third-party action** — `peter-evans/create-pull-request` is pinned to a full commit SHA (`22a9089`, v7) instead of the mutable `@v7` tag, and `base: main` is set explicitly.
- **Stale-PR guidance** — the generated PR body now explains that the branch is recreated from current `main` at run time and tells reviewers to merge promptly (or close + re-run rather than merge) if `main` advances while the PR sits open. This is the root cause of the PR that had to be closed as a revert-in-waiting.

## Verification
- `pytest -q` → **62 passed**, DeprecationWarning gone
- `scripts/validate.py` → 7,720/7,720 entries valid
- `auto-refresh.yml` parses as valid YAML; concurrency block and `Unit tests` step confirmed present

🤖 Generated with [Claude Code](https://claude.com/claude-code)