### PR TITLE
Fix data drift: restore 6 dropped AIAAIC incidents + resync outputs

### DIFF
--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -4,7 +4,7 @@ Single source of truth for GenAI and agentic AI security incidents.
 Each entry is mapped to **OWASP LLM Top 10 (2025)**, **OWASP Agentic Top 10 (ASI)**, **NIST AI RMF**, and **MITRE ATLAS**.
 
 - **Version:** 2.0.0
-- **Generated:** 2026-05-26
+- **Generated:** 2026-05-29
 - **Total incidents:** **7,720**
 - **Date range:** 1983 – 2026
 - **With CVE:** 1,654
@@ -82,7 +82,7 @@ Auto-generated from the current dataset. SVGs live under [`docs/charts/`](docs/c
 | LLM04 | Data and Model Poisoning | 124 |
 | LLM05 | Improper Output Handling | 3,122 |
 | LLM06 | Excessive Agency | 768 |
-| LLM07 | System Prompt Leakage | 724 |
+| LLM07 | System Prompt Leakage | 723 |
 | LLM08 | Vector and Embedding Weaknesses | 25 |
 | LLM09 | Misinformation | 1,930 |
 | LLM10 | Unbounded Consumption | 45 |
@@ -114,7 +114,7 @@ Auto-generated from the current dataset. SVGs live under [`docs/charts/`](docs/c
 | `AML.T0053` | 1,149 |
 | `AML.T0012` | 811 |
 | `AML.T0057` | 782 |
-| `AML.T0056` | 724 |
+| `AML.T0056` | 723 |
 | `AML.T0051` | 430 |
 | `AML.T0049` | 175 |
 | `AML.T0024` | 171 |
@@ -3279,7 +3279,7 @@ All **7,720** incidents in a single table, newest-first. Each `INC-*****` link o
 | 3,149 | 2025 | [`INC-02334`](docs/incidents/2025.md#inc-02334) | ARC Raiders slammed for replacing voice actors with AI | Medium | LLM06, LLM07 | ASI09 |  |
 | 3,150 | 2025 | [`INC-02343`](docs/incidents/2025.md#inc-02343) | Audio deepfake scam imitates Italian defence minister Guido Crosetto | Medium | LLM02, LLM03, LLM09 | ASI02, ASI03, ASI09 |  |
 | 3,151 | 2025 | [`INC-02344`](docs/incidents/2025.md#inc-02344) | Australian activist Caitlin Roper targeted with AI-generated violent threats, images | Medium | LLM06, LLM07 | ASI09 |  |
-| 3,152 | 2025 | [`INC-02346`](docs/incidents/2025.md#inc-02346) | Australian bank employees train chatbot, are fired | Medium | LLM07 |  |  |
+| 3,152 | 2025 | [`INC-02346`](docs/incidents/2025.md#inc-02346) | Australian Bank employees train chatbot, are fired | Medium | LLM07 |  |  |
 | 3,153 | 2025 | [`INC-02349`](docs/incidents/2025.md#inc-02349) | Autonomous AI coding agent deletes company database | Medium | LLM07 |  |  |
 | 3,154 | 2025 | [`INC-02355`](docs/incidents/2025.md#inc-02355) | Azure PromptFlow RCE via improper isolation (CVE-2025-24986) | Critical | LLM05, LLM06 | ASI04 |  |
 | 3,155 | 2025 | [`INC-02359`](docs/incidents/2025.md#inc-02359) | Beijing uses AI to suppress Tibetan refugees in Nepal | Medium | LLM06, LLM07 | ASI09 |  |
@@ -7488,7 +7488,7 @@ All **7,720** incidents in a single table, newest-first. Each `INC-*****` link o
 | 7,358 | 2018 | [`INC-07347`](docs/incidents/2018.md#inc-07347) | TV advert propels Amazon Alexa to order cat food | Medium | LLM02, LLM03 | ASI02, ASI03 |  |
 | 7,359 | 2018 | [`INC-07350`](docs/incidents/2018.md#inc-07350) | Uber autonomous vehicle pedestrian fatality (Tempe, AZ) | Critical |  | ASI06 |  |
 | 7,360 | 2018 | [`INC-07352`](docs/incidents/2018.md#inc-07352) | Uber ID algorithm suspends transgender drivers | Medium | LLM06, LLM07 | ASI09 |  |
-| 7,361 | 2018 | [`INC-07353`](docs/incidents/2018.md#inc-07353) | Uber self-driving car kills Arizona pedestrian | Critical | LLM05, LLM06, LLM07 | ASI08, ASI09 |  |
+| 7,361 | 2018 | [`INC-07353`](docs/incidents/2018.md#inc-07353) | Uber self-driving car kills Arizona pedestrian | Critical | LLM05, LLM06 | ASI08, ASI09 |  |
 | 7,362 | 2018 | [`INC-07356`](docs/incidents/2018.md#inc-07356) | Waze directs tourists to drive into Vermont lake | Medium | LLM05 | ASI08 |  |
 | 7,363 | 2018 | [`INC-07358`](docs/incidents/2018.md#inc-07358) | Xinhua deepfake news anchors stir scepticism, distrust | Medium | LLM09 | ASI09 |  |
 | 7,364 | 2017-12-23 | [`INC-07379`](docs/incidents/2017.md#inc-07379) | Bad AI-Written Christmas Carols | Medium | LLM05 | ASI08 |  |

--- a/data/incidents.json
+++ b/data/incidents.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generated": "2026-05-26",
+  "generated": "2026-05-29",
   "description": "Single source of truth for GenAI and agentic AI security incidents. Each entry is mapped to OWASP LLM Top 10 (2025), OWASP Agentic ASI Top 10, NIST AI RMF (AI 100-1), and MITRE ATLAS where applicable.",
   "schema": "schema/incident.schema.json",
   "incident_count": 7720,
@@ -174,7 +174,7 @@
         "chatbot"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -259,7 +259,7 @@
         "accountability"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -339,7 +339,7 @@
         "thin-wrapper"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -414,7 +414,7 @@
         "caching"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -498,7 +498,7 @@
         "code-generation"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -582,7 +582,7 @@
         "hugging-face"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -677,7 +677,7 @@
         "enterprise"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -767,7 +767,7 @@
         "phishing"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -895,7 +895,7 @@
         "rce"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "cve_ids": [
         "CVE-2023-36188",
         "CVE-2023-36258",
@@ -989,7 +989,7 @@
         "system-prompt-leakage"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -1068,7 +1068,7 @@
         "volume-attack"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -1151,7 +1151,7 @@
         "gpt-4v"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -1277,7 +1277,7 @@
         "worm"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -1369,7 +1369,7 @@
         "no-oversight"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -1455,7 +1455,7 @@
         "tool-abuse"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -1584,7 +1584,7 @@
         "empirical"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -1722,7 +1722,7 @@
         "worm"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -1872,7 +1872,7 @@
         "summarisation"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -1979,7 +1979,7 @@
         "supply-chain"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -2080,7 +2080,7 @@
         "cfo-fraud"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -2164,7 +2164,7 @@
         "frontier-models"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -2257,7 +2257,7 @@
         "safety-bypass"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-11",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -2361,7 +2361,7 @@
         "usenix-2025"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -2457,7 +2457,7 @@
         "skeleton-key"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -2553,7 +2553,7 @@
         "premature-deployment"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -2641,7 +2641,7 @@
         "2025"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -2732,7 +2732,7 @@
         "2025"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -2928,7 +2928,7 @@
         "training-data"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "ai-harm"
     },
@@ -3011,7 +3011,7 @@
         "2025"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -3108,7 +3108,7 @@
         "2025"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -3185,7 +3185,7 @@
         "2025"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -3281,7 +3281,7 @@
         "2025"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -3353,7 +3353,7 @@
         "2024"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -3557,7 +3557,7 @@
         "worker-exploitation"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -3639,7 +3639,7 @@
         "2024"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -3730,7 +3730,7 @@
         "2024"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -3831,7 +3831,7 @@
         "2024"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -3925,7 +3925,7 @@
         "2024"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -4014,7 +4014,7 @@
         "safety-alignment"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -4099,7 +4099,7 @@
         "brand-damage"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -4186,7 +4186,7 @@
         "nhi"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -4261,7 +4261,7 @@
         "os-level"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -4341,7 +4341,7 @@
         "data-quality"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -4431,7 +4431,7 @@
         "trust"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -4595,7 +4595,7 @@
         "attribution"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -4675,7 +4675,7 @@
         "attribution"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -4784,7 +4784,7 @@
         "sleeper-agents"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -4889,7 +4889,7 @@
         "tool-poisoning"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -4973,7 +4973,7 @@
         "image-generation"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -5051,7 +5051,7 @@
         "data-governance"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -5151,7 +5151,7 @@
         "system-prompt"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -5221,7 +5221,7 @@
         "autonomous-vehicle"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -5307,7 +5307,7 @@
         "developer-tools"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -5390,7 +5390,7 @@
         "compliance"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -5478,7 +5478,7 @@
         "browser"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -5560,7 +5560,7 @@
         "mfa"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -5711,7 +5711,7 @@
         "government-ban"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -5799,7 +5799,7 @@
         "reward-hacking"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -5885,7 +5885,7 @@
         "training-data"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "ai-harm"
     },
@@ -5971,7 +5971,7 @@
         "offensive-ai"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -6129,7 +6129,7 @@
         "synthetic-media"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -6297,7 +6297,7 @@
         "nhi"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -6383,7 +6383,7 @@
         "healthcare"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -6481,7 +6481,7 @@
         "supply-chain"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -6558,7 +6558,7 @@
         "misinterpretation"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "reviewed",
       "corpus": "security"
     },
@@ -6736,7 +6736,7 @@
         "unauthorized-access"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -6827,7 +6827,7 @@
         "supply-chain"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -6944,7 +6944,7 @@
         "salesforce"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "cve_ids": [
         "CVE-2025-10875",
         "CVE-2025-64318",
@@ -7130,7 +7130,7 @@
         "zero-click"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "cve_ids": [
         "CVE-2025-32711"
       ],
@@ -7320,7 +7320,7 @@
         "sev-1"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -7513,7 +7513,7 @@
         "supply-chain"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -7600,7 +7600,7 @@
         "supply-chain"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -7708,7 +7708,7 @@
         "xpia"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "cve_ids": [
         "CVE-2026-26133"
       ],
@@ -7793,7 +7793,7 @@
         "vulnerability-research"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "cve_ids": [
         "CVE-2026-21536"
       ],
@@ -7881,7 +7881,7 @@
         "vscode"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -7978,7 +7978,7 @@
         "supply-chain"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -8059,7 +8059,7 @@
         "vibe-coding"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -8146,7 +8146,7 @@
         "web-content"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -8253,7 +8253,7 @@
         "zero-click"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -8355,7 +8355,7 @@
         "openclaw"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "cve_ids": [
         "CVE-2026-25253"
       ],
@@ -8452,7 +8452,7 @@
         "servicenow"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "cve_ids": [
         "CVE-2025-12420"
       ],
@@ -8567,7 +8567,7 @@
         "tool-misuse"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -8660,7 +8660,7 @@
         "vibe-coding"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -8753,7 +8753,7 @@
         "zero-click"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -8837,7 +8837,7 @@
         "usenix"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -8922,7 +8922,7 @@
         "supply-chain"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -9023,7 +9023,7 @@
         "whatsapp"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -9105,7 +9105,7 @@
         "privacy"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -9230,7 +9230,7 @@
         "rce"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "cve_ids": [
         "CVE-2025-59528"
       ],
@@ -9323,7 +9323,7 @@
         "systemic-risk"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -10148,7 +10148,7 @@
         "nvd"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -10450,7 +10450,7 @@
         "prompt-injection"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -10553,7 +10553,7 @@
       ],
       "tags": [],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -11523,7 +11523,7 @@
       ],
       "tags": [],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -12838,7 +12838,7 @@
         "prompt-injection"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -13191,7 +13191,7 @@
       ],
       "tags": [],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -13269,7 +13269,7 @@
         "rce"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -14032,7 +14032,7 @@
         "windsurf"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -14518,7 +14518,7 @@
         "nvd"
       ],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -14891,7 +14891,7 @@
       ],
       "tags": [],
       "added": "2026-05-11",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "curated",
       "corpus": "security"
     },
@@ -20533,309 +20533,6 @@
       ],
       "added": "2026-05-16",
       "updated": "2026-05-16",
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07724",
-      "source_ids": [
-        "AIAAIC2263"
-      ],
-      "title": "Chinese AI actors spark personality rights controversy",
-      "date": "2026",
-      "year": 2026,
-      "category": "real-world",
-      "description": "AIAAIC report: Chinese AI actors spark personality rights controversy. Technology: Generative AI. Purpose: Create AI-generated performers. Ethical issues: Accountability; Consent; Employment; Transparency.",
-      "attack_vector": "other",
-      "affected": "Youhug Media",
-      "severity": "Medium",
-      "owasp_llm": [
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048.003",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "references": [
-        {
-          "title": "AIAAIC entry",
-          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chinese-ai-actors-spark-personality-rights-controversy",
-          "type": "report"
-        }
-      ],
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-china"
-      ],
-      "added": "2026-05-26",
-      "updated": "2026-05-26",
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07725",
-      "source_ids": [
-        "AIAAIC2262"
-      ],
-      "title": "German TV star accuses husband of spreading deepfake porn images of her",
-      "date": "2024",
-      "year": 2024,
-      "category": "real-world",
-      "description": "AIAAIC report: German TV star accuses husband of spreading deepfake porn images of her. Technology: Deepfake. Purpose: Harass ex-wife. Ethical issues: Accountability; Authenticity/integrity; Privacy/surveillance; Safety; Transparency. Reported consequences: Legal complaint/investigation; Legislation introduction/update.",
-      "attack_vector": "deepfake",
-      "affected": "Christian Ulmen",
-      "severity": "Medium",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07",
-        "LLM09"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7",
-        "MEASURE-2.8"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056",
-        "AML.T0058"
-      ],
-      "references": [
-        {
-          "title": "AIAAIC entry",
-          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/german-tv-star-accuses-husband-of-spreading-deepfake-porn-images-of-her",
-          "type": "report"
-        }
-      ],
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-germany;-spain"
-      ],
-      "added": "2026-05-26",
-      "updated": "2026-05-26",
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07726",
-      "source_ids": [
-        "AIAAIC2261"
-      ],
-      "title": "AI chatbots lure vulnerable gamblers to unlicensed betting websites",
-      "date": "2026",
-      "year": 2026,
-      "category": "real-world",
-      "description": "AIAAIC report: AI chatbots lure vulnerable gamblers to unlicensed betting websites. System: ChatGPT; Claude; Copilot; Gemini; Grok; Le Chat; Meta AI. Technology: Generative AI. Purpose: Recommend online casinos. Ethical issues: Accountability; Safety; Transparency.",
-      "attack_vector": "other",
-      "affected": "Anthropic; Google; Meta; Microsoft; Mistral; OpenAI; xAI",
-      "severity": "Medium",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "references": [
-        {
-          "title": "AIAAIC entry",
-          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/ai-chatbots-lure-vulnerable-gamblers-to-unlicensed-betting-websites",
-          "type": "report"
-        }
-      ],
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-gambling",
-        "juris-austria;-belgium;-france"
-      ],
-      "added": "2026-05-26",
-      "updated": "2026-05-26",
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07727",
-      "source_ids": [
-        "AIAAIC2260"
-      ],
-      "title": "ChatGPT accused of enabling Florida State University mass shooting",
-      "date": "2025",
-      "year": 2025,
-      "category": "real-world",
-      "description": "AIAAIC report: ChatGPT accused of enabling Florida State University mass shooting. System: ChatGPT. Technology: Generative AI. Purpose: Plan mass shooting. Ethical issues: Accountability; Alignment; Safety. Reported consequences: Litigation.",
-      "attack_vector": "other",
-      "affected": "OpenAI",
-      "severity": "Medium",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053"
-      ],
-      "references": [
-        {
-          "title": "AIAAIC entry",
-          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-accused-of-enabling-florida-state-university-mass-shooting",
-          "type": "report"
-        }
-      ],
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-education",
-        "juris-florida"
-      ],
-      "added": "2026-05-26",
-      "updated": "2026-05-26",
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07728",
-      "source_ids": [
-        "AIAAIC2259"
-      ],
-      "title": "Meta, YouTube found liable for addicting child to social media",
-      "date": "2012",
-      "year": 2012,
-      "category": "real-world",
-      "description": "AIAAIC report: Meta, YouTube found liable for addicting child to social media. System: Explore. Technology: Machine learning; Recommendation algorithm. Purpose: Maximise user retention. Ethical issues: Accountability; Safety; Transparency. Reported consequences: Litigation; Fine/settlement.",
-      "attack_vector": "other",
-      "affected": "Google; Meta",
-      "severity": "Medium",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "references": [
-        {
-          "title": "AIAAIC entry",
-          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/meta-youtube-found-liable-for-addicting-child-to-social-media",
-          "type": "report"
-        }
-      ],
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-mental-health",
-        "juris-california"
-      ],
-      "added": "2026-05-26",
-      "updated": "2026-05-26",
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07729",
-      "source_ids": [
-        "AIAAIC2258"
-      ],
-      "title": "ChatGPT advises exec on how to fire company founders to avoid payout",
-      "date": "2025",
-      "year": 2025,
-      "category": "real-world",
-      "description": "AIAAIC report: ChatGPT advises exec on how to fire company founders to avoid payout. System: ChatGPT. Technology: Generative AI. Purpose: Provide legal advice. Ethical issues: Accountability; Transparency. Reported consequences: Litigation; Fine/settlement.",
-      "attack_vector": "other",
-      "affected": "OpenAI",
-      "severity": "Medium",
-      "owasp_llm": [
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048.003",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "references": [
-        {
-          "title": "AIAAIC entry",
-          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-advises-exec-on-how-to-fire-company-founders-to-avoid-payout",
-          "type": "report"
-        }
-      ],
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-delaware"
-      ],
-      "added": "2026-05-26",
-      "updated": "2026-05-26",
       "quality_tier": "auto",
       "corpus": "security"
     },
@@ -29208,11 +28905,11 @@
       "source_ids": [
         "AIAAIC2072"
       ],
-      "title": "Australian bank employees train chatbot, are fired",
+      "title": "Australian Bank employees train chatbot, are fired",
       "date": "2025",
       "year": 2025,
       "category": "real-world",
-      "description": "AIAAIC report: Australian bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.",
+      "description": "AIAAIC report: Australian Bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.",
       "attack_vector": "other",
       "affected": "Commonwealth Bank of Australia",
       "severity": "Medium",
@@ -29240,7 +28937,7 @@
         "juris-australia"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "auto",
       "corpus": "ai-harm"
     },
@@ -61496,11 +61193,11 @@
       "tags": [
         "aiaaic",
         "aiaaic-sheet",
-        "sector-gambling",
+        "sector-gaming",
         "juris-uk"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "auto",
       "corpus": "security"
     },
@@ -79261,14 +78958,13 @@
       "date": "2018",
       "year": 2018,
       "category": "real-world",
-      "description": "AIAAIC report: Uber self-driving car kills Arizona pedestrian. System: Automated Driving System. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Consent; Oversight; Safety; Transparency. Reported consequences: Regulatory investigation; Litigation; Settlement/fine. Response: System suspension.",
+      "description": "AIAAIC report: Uber self-driving car kills Arizona pedestrian. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Safety. Reported consequences: Regulatory investigation; Litigation. Response: System suspension.",
       "attack_vector": "other",
       "affected": "Uber",
       "severity": "Critical",
       "owasp_llm": [
         "LLM05",
-        "LLM06",
-        "LLM07"
+        "LLM06"
       ],
       "owasp_asi": [
         "ASI08",
@@ -79283,8 +78979,7 @@
         "AML.T0048",
         "AML.T0048.003",
         "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
+        "AML.T0053"
       ],
       "references": [
         {
@@ -79300,7 +78995,7 @@
         "juris-usa"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-26",
+      "updated": "2026-05-29",
       "quality_tier": "auto",
       "corpus": "security"
     },
@@ -84466,6 +84161,309 @@
         "juris-australia"
       ],
       "added": "2026-05-16",
+      "updated": "2026-05-26",
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07724",
+      "source_ids": [
+        "AIAAIC2263"
+      ],
+      "title": "Chinese AI actors spark personality rights controversy",
+      "date": "2026",
+      "year": 2026,
+      "category": "real-world",
+      "description": "AIAAIC report: Chinese AI actors spark personality rights controversy. Technology: Generative AI. Purpose: Create AI-generated performers. Ethical issues: Accountability; Consent; Employment; Transparency.",
+      "attack_vector": "other",
+      "affected": "Youhug Media",
+      "severity": "Medium",
+      "owasp_llm": [
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048.003",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "references": [
+        {
+          "title": "AIAAIC entry",
+          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chinese-ai-actors-spark-personality-rights-controversy",
+          "type": "report"
+        }
+      ],
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-china"
+      ],
+      "added": "2026-05-26",
+      "updated": "2026-05-26",
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07725",
+      "source_ids": [
+        "AIAAIC2262"
+      ],
+      "title": "German TV star accuses husband of spreading deepfake porn images of her",
+      "date": "2024",
+      "year": 2024,
+      "category": "real-world",
+      "description": "AIAAIC report: German TV star accuses husband of spreading deepfake porn images of her. Technology: Deepfake. Purpose: Harass ex-wife. Ethical issues: Accountability; Authenticity/integrity; Privacy/surveillance; Safety; Transparency. Reported consequences: Legal complaint/investigation; Legislation introduction/update.",
+      "attack_vector": "deepfake",
+      "affected": "Christian Ulmen",
+      "severity": "Medium",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07",
+        "LLM09"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7",
+        "MEASURE-2.8"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056",
+        "AML.T0058"
+      ],
+      "references": [
+        {
+          "title": "AIAAIC entry",
+          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/german-tv-star-accuses-husband-of-spreading-deepfake-porn-images-of-her",
+          "type": "report"
+        }
+      ],
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-germany;-spain"
+      ],
+      "added": "2026-05-26",
+      "updated": "2026-05-26",
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07726",
+      "source_ids": [
+        "AIAAIC2261"
+      ],
+      "title": "AI chatbots lure vulnerable gamblers to unlicensed betting websites",
+      "date": "2026",
+      "year": 2026,
+      "category": "real-world",
+      "description": "AIAAIC report: AI chatbots lure vulnerable gamblers to unlicensed betting websites. System: ChatGPT; Claude; Copilot; Gemini; Grok; Le Chat; Meta AI. Technology: Generative AI. Purpose: Recommend online casinos. Ethical issues: Accountability; Safety; Transparency.",
+      "attack_vector": "other",
+      "affected": "Anthropic; Google; Meta; Microsoft; Mistral; OpenAI; xAI",
+      "severity": "Medium",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "references": [
+        {
+          "title": "AIAAIC entry",
+          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/ai-chatbots-lure-vulnerable-gamblers-to-unlicensed-betting-websites",
+          "type": "report"
+        }
+      ],
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-gambling",
+        "juris-austria;-belgium;-france"
+      ],
+      "added": "2026-05-26",
+      "updated": "2026-05-26",
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07727",
+      "source_ids": [
+        "AIAAIC2260"
+      ],
+      "title": "ChatGPT accused of enabling Florida State University mass shooting",
+      "date": "2025",
+      "year": 2025,
+      "category": "real-world",
+      "description": "AIAAIC report: ChatGPT accused of enabling Florida State University mass shooting. System: ChatGPT. Technology: Generative AI. Purpose: Plan mass shooting. Ethical issues: Accountability; Alignment; Safety. Reported consequences: Litigation.",
+      "attack_vector": "other",
+      "affected": "OpenAI",
+      "severity": "Medium",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053"
+      ],
+      "references": [
+        {
+          "title": "AIAAIC entry",
+          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-accused-of-enabling-florida-state-university-mass-shooting",
+          "type": "report"
+        }
+      ],
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-education",
+        "juris-florida"
+      ],
+      "added": "2026-05-26",
+      "updated": "2026-05-26",
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07728",
+      "source_ids": [
+        "AIAAIC2259"
+      ],
+      "title": "Meta, YouTube found liable for addicting child to social media",
+      "date": "2012",
+      "year": 2012,
+      "category": "real-world",
+      "description": "AIAAIC report: Meta, YouTube found liable for addicting child to social media. System: Explore. Technology: Machine learning; Recommendation algorithm. Purpose: Maximise user retention. Ethical issues: Accountability; Safety; Transparency. Reported consequences: Litigation; Fine/settlement.",
+      "attack_vector": "other",
+      "affected": "Google; Meta",
+      "severity": "Medium",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "references": [
+        {
+          "title": "AIAAIC entry",
+          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/meta-youtube-found-liable-for-addicting-child-to-social-media",
+          "type": "report"
+        }
+      ],
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-mental-health",
+        "juris-california"
+      ],
+      "added": "2026-05-26",
+      "updated": "2026-05-26",
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07729",
+      "source_ids": [
+        "AIAAIC2258"
+      ],
+      "title": "ChatGPT advises exec on how to fire company founders to avoid payout",
+      "date": "2025",
+      "year": 2025,
+      "category": "real-world",
+      "description": "AIAAIC report: ChatGPT advises exec on how to fire company founders to avoid payout. System: ChatGPT. Technology: Generative AI. Purpose: Provide legal advice. Ethical issues: Accountability; Transparency. Reported consequences: Litigation; Fine/settlement.",
+      "attack_vector": "other",
+      "affected": "OpenAI",
+      "severity": "Medium",
+      "owasp_llm": [
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048.003",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "references": [
+        {
+          "title": "AIAAIC entry",
+          "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-advises-exec-on-how-to-fire-company-founders-to-avoid-payout",
+          "type": "report"
+        }
+      ],
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-delaware"
+      ],
+      "added": "2026-05-26",
       "updated": "2026-05-26",
       "quality_tier": "auto",
       "corpus": "security"

--- a/data/incidents.min.json
+++ b/data/incidents.min.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generated": "2026-05-26",
+  "generated": "2026-05-29",
   "incident_count": 7720,
   "incidents": [
     {
@@ -12533,243 +12533,6 @@
       "corpus": "security"
     },
     {
-      "id": "INC-07724",
-      "title": "Chinese AI actors spark personality rights controversy",
-      "date": "2026",
-      "year": 2026,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048.003",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chinese-ai-actors-spark-personality-rights-controversy",
-      "description": "AIAAIC report: Chinese AI actors spark personality rights controversy. Technology: Generative AI. Purpose: Create AI-generated performers. Ethical issues: Accountability; Consent; Employment; Transparency.",
-      "affected": "Youhug Media",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-china"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07725",
-      "title": "German TV star accuses husband of spreading deepfake porn images of her",
-      "date": "2024",
-      "year": 2024,
-      "severity": "Medium",
-      "attack_vector": "deepfake",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07",
-        "LLM09"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7",
-        "MEASURE-2.8"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056",
-        "AML.T0058"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/german-tv-star-accuses-husband-of-spreading-deepfake-porn-images-of-her",
-      "description": "AIAAIC report: German TV star accuses husband of spreading deepfake porn images of her. Technology: Deepfake. Purpose: Harass ex-wife. Ethical issues: Accountability; Authenticity/integrity; Privacy/surveillance; Safety; Transparency. Reported consequences: Legal…",
-      "affected": "Christian Ulmen",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-germany;-spain"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07726",
-      "title": "AI chatbots lure vulnerable gamblers to unlicensed betting websites",
-      "date": "2026",
-      "year": 2026,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/ai-chatbots-lure-vulnerable-gamblers-to-unlicensed-betting-websites",
-      "description": "AIAAIC report: AI chatbots lure vulnerable gamblers to unlicensed betting websites. System: ChatGPT; Claude; Copilot; Gemini; Grok; Le Chat; Meta AI. Technology: Generative AI. Purpose: Recommend online casinos. Ethical issues: Accountability; Safety; Transparency.",
-      "affected": "Anthropic; Google; Meta; Microsoft; Mistral; OpenAI; xAI",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-gambling",
-        "juris-austria;-belgium;-france"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07727",
-      "title": "ChatGPT accused of enabling Florida State University mass shooting",
-      "date": "2025",
-      "year": 2025,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-accused-of-enabling-florida-state-university-mass-shooting",
-      "description": "AIAAIC report: ChatGPT accused of enabling Florida State University mass shooting. System: ChatGPT. Technology: Generative AI. Purpose: Plan mass shooting. Ethical issues: Accountability; Alignment; Safety. Reported consequences: Litigation.",
-      "affected": "OpenAI",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-education",
-        "juris-florida"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07728",
-      "title": "Meta, YouTube found liable for addicting child to social media",
-      "date": "2012",
-      "year": 2012,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/meta-youtube-found-liable-for-addicting-child-to-social-media",
-      "description": "AIAAIC report: Meta, YouTube found liable for addicting child to social media. System: Explore. Technology: Machine learning; Recommendation algorithm. Purpose: Maximise user retention. Ethical issues: Accountability; Safety; Transparency. Reported consequences: Litigation;…",
-      "affected": "Google; Meta",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-mental-health",
-        "juris-california"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07729",
-      "title": "ChatGPT advises exec on how to fire company founders to avoid payout",
-      "date": "2025",
-      "year": 2025,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048.003",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-advises-exec-on-how-to-fire-company-founders-to-avoid-payout",
-      "description": "AIAAIC report: ChatGPT advises exec on how to fire company founders to avoid payout. System: ChatGPT. Technology: Generative AI. Purpose: Provide legal advice. Ethical issues: Accountability; Transparency. Reported consequences: Litigation; Fine/settlement.",
-      "affected": "OpenAI",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-delaware"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
       "id": "INC-03365",
       "title": "Welshman kills mother with sledgehammer after speaking to Discord AI bot",
       "date": "2025",
@@ -19220,7 +18983,7 @@
     },
     {
       "id": "INC-02346",
-      "title": "Australian bank employees train chatbot, are fired",
+      "title": "Australian Bank employees train chatbot, are fired",
       "date": "2025",
       "year": 2025,
       "severity": "Medium",
@@ -19237,7 +19000,7 @@
       ],
       "cve_ids": [],
       "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/australian-bank-employees-train-chatbot-are-fired",
-      "description": "AIAAIC report: Australian bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.",
+      "description": "AIAAIC report: Australian Bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.",
       "affected": "Commonwealth Bank of Australia",
       "tags": [
         "aiaaic",
@@ -43475,7 +43238,7 @@
       "tags": [
         "aiaaic",
         "aiaaic-sheet",
-        "sector-gambling",
+        "sector-gaming",
         "juris-uk"
       ],
       "quality_tier": "auto",
@@ -56881,8 +56644,7 @@
       "attack_vector": "other",
       "owasp_llm": [
         "LLM05",
-        "LLM06",
-        "LLM07"
+        "LLM06"
       ],
       "owasp_asi": [
         "ASI08",
@@ -56897,12 +56659,11 @@
         "AML.T0048",
         "AML.T0048.003",
         "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
+        "AML.T0053"
       ],
       "cve_ids": [],
       "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/uber-self-driving-car-pedestrian-fatality",
-      "description": "AIAAIC report: Uber self-driving car kills Arizona pedestrian. System: Automated Driving System. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Consent; Oversight;…",
+      "description": "AIAAIC report: Uber self-driving car kills Arizona pedestrian. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Safety. Reported consequences: Regulatory investigation;…",
       "affected": "Uber",
       "tags": [
         "aiaaic",
@@ -60864,6 +60625,243 @@
         "aiaaic-sheet",
         "sector-media/entertainment/sports/arts",
         "juris-australia"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07724",
+      "title": "Chinese AI actors spark personality rights controversy",
+      "date": "2026",
+      "year": 2026,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048.003",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chinese-ai-actors-spark-personality-rights-controversy",
+      "description": "AIAAIC report: Chinese AI actors spark personality rights controversy. Technology: Generative AI. Purpose: Create AI-generated performers. Ethical issues: Accountability; Consent; Employment; Transparency.",
+      "affected": "Youhug Media",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-china"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07725",
+      "title": "German TV star accuses husband of spreading deepfake porn images of her",
+      "date": "2024",
+      "year": 2024,
+      "severity": "Medium",
+      "attack_vector": "deepfake",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07",
+        "LLM09"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7",
+        "MEASURE-2.8"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056",
+        "AML.T0058"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/german-tv-star-accuses-husband-of-spreading-deepfake-porn-images-of-her",
+      "description": "AIAAIC report: German TV star accuses husband of spreading deepfake porn images of her. Technology: Deepfake. Purpose: Harass ex-wife. Ethical issues: Accountability; Authenticity/integrity; Privacy/surveillance; Safety; Transparency. Reported consequences: Legal…",
+      "affected": "Christian Ulmen",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-germany;-spain"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07726",
+      "title": "AI chatbots lure vulnerable gamblers to unlicensed betting websites",
+      "date": "2026",
+      "year": 2026,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/ai-chatbots-lure-vulnerable-gamblers-to-unlicensed-betting-websites",
+      "description": "AIAAIC report: AI chatbots lure vulnerable gamblers to unlicensed betting websites. System: ChatGPT; Claude; Copilot; Gemini; Grok; Le Chat; Meta AI. Technology: Generative AI. Purpose: Recommend online casinos. Ethical issues: Accountability; Safety; Transparency.",
+      "affected": "Anthropic; Google; Meta; Microsoft; Mistral; OpenAI; xAI",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-gambling",
+        "juris-austria;-belgium;-france"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07727",
+      "title": "ChatGPT accused of enabling Florida State University mass shooting",
+      "date": "2025",
+      "year": 2025,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-accused-of-enabling-florida-state-university-mass-shooting",
+      "description": "AIAAIC report: ChatGPT accused of enabling Florida State University mass shooting. System: ChatGPT. Technology: Generative AI. Purpose: Plan mass shooting. Ethical issues: Accountability; Alignment; Safety. Reported consequences: Litigation.",
+      "affected": "OpenAI",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-education",
+        "juris-florida"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07728",
+      "title": "Meta, YouTube found liable for addicting child to social media",
+      "date": "2012",
+      "year": 2012,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/meta-youtube-found-liable-for-addicting-child-to-social-media",
+      "description": "AIAAIC report: Meta, YouTube found liable for addicting child to social media. System: Explore. Technology: Machine learning; Recommendation algorithm. Purpose: Maximise user retention. Ethical issues: Accountability; Safety; Transparency. Reported consequences: Litigation;…",
+      "affected": "Google; Meta",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-mental-health",
+        "juris-california"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07729",
+      "title": "ChatGPT advises exec on how to fire company founders to avoid payout",
+      "date": "2025",
+      "year": 2025,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048.003",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-advises-exec-on-how-to-fire-company-founders-to-avoid-payout",
+      "description": "AIAAIC report: ChatGPT advises exec on how to fire company founders to avoid payout. System: ChatGPT. Technology: Generative AI. Purpose: Provide legal advice. Ethical issues: Accountability; Transparency. Reported consequences: Litigation; Fine/settlement.",
+      "affected": "OpenAI",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-delaware"
       ],
       "quality_tier": "auto",
       "corpus": "security"

--- a/docs/charts/owasp_llm.svg
+++ b/docs/charts/owasp_llm.svg
@@ -20,8 +20,8 @@
 <rect x="220" y="146" width="118.1" height="14" fill="#0a58ca" rx="2"><title>Excessive Agency: 768</title></rect>
 <text x="344.1" y="157" fill="#666">768</text>
 <text x="212" y="179" text-anchor="end" fill="#333">LLM07 · System Prompt Leakage</text>
-<rect x="220" y="168" width="111.3" height="14" fill="#0a58ca" rx="2"><title>System Prompt Leakage: 724</title></rect>
-<text x="337.3" y="179" fill="#666">724</text>
+<rect x="220" y="168" width="111.2" height="14" fill="#0a58ca" rx="2"><title>System Prompt Leakage: 723</title></rect>
+<text x="337.2" y="179" fill="#666">723</text>
 <text x="212" y="201" text-anchor="end" fill="#333">LLM08 · Vector and Embedding Weaknesses</text>
 <rect x="220" y="190" width="3.8" height="14" fill="#0a58ca" rx="2"><title>Vector and Embedding Weaknesses: 25</title></rect>
 <text x="229.8" y="201" fill="#666">25</text>

--- a/docs/data/incidents.min.json
+++ b/docs/data/incidents.min.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generated": "2026-05-26",
+  "generated": "2026-05-29",
   "incident_count": 7720,
   "incidents": [
     {
@@ -12533,243 +12533,6 @@
       "corpus": "security"
     },
     {
-      "id": "INC-07724",
-      "title": "Chinese AI actors spark personality rights controversy",
-      "date": "2026",
-      "year": 2026,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048.003",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chinese-ai-actors-spark-personality-rights-controversy",
-      "description": "AIAAIC report: Chinese AI actors spark personality rights controversy. Technology: Generative AI. Purpose: Create AI-generated performers. Ethical issues: Accountability; Consent; Employment; Transparency.",
-      "affected": "Youhug Media",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-china"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07725",
-      "title": "German TV star accuses husband of spreading deepfake porn images of her",
-      "date": "2024",
-      "year": 2024,
-      "severity": "Medium",
-      "attack_vector": "deepfake",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07",
-        "LLM09"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7",
-        "MEASURE-2.8"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056",
-        "AML.T0058"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/german-tv-star-accuses-husband-of-spreading-deepfake-porn-images-of-her",
-      "description": "AIAAIC report: German TV star accuses husband of spreading deepfake porn images of her. Technology: Deepfake. Purpose: Harass ex-wife. Ethical issues: Accountability; Authenticity/integrity; Privacy/surveillance; Safety; Transparency. Reported consequences: Legal…",
-      "affected": "Christian Ulmen",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-germany;-spain"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07726",
-      "title": "AI chatbots lure vulnerable gamblers to unlicensed betting websites",
-      "date": "2026",
-      "year": 2026,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/ai-chatbots-lure-vulnerable-gamblers-to-unlicensed-betting-websites",
-      "description": "AIAAIC report: AI chatbots lure vulnerable gamblers to unlicensed betting websites. System: ChatGPT; Claude; Copilot; Gemini; Grok; Le Chat; Meta AI. Technology: Generative AI. Purpose: Recommend online casinos. Ethical issues: Accountability; Safety; Transparency.",
-      "affected": "Anthropic; Google; Meta; Microsoft; Mistral; OpenAI; xAI",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-gambling",
-        "juris-austria;-belgium;-france"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07727",
-      "title": "ChatGPT accused of enabling Florida State University mass shooting",
-      "date": "2025",
-      "year": 2025,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-accused-of-enabling-florida-state-university-mass-shooting",
-      "description": "AIAAIC report: ChatGPT accused of enabling Florida State University mass shooting. System: ChatGPT. Technology: Generative AI. Purpose: Plan mass shooting. Ethical issues: Accountability; Alignment; Safety. Reported consequences: Litigation.",
-      "affected": "OpenAI",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-education",
-        "juris-florida"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07728",
-      "title": "Meta, YouTube found liable for addicting child to social media",
-      "date": "2012",
-      "year": 2012,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/meta-youtube-found-liable-for-addicting-child-to-social-media",
-      "description": "AIAAIC report: Meta, YouTube found liable for addicting child to social media. System: Explore. Technology: Machine learning; Recommendation algorithm. Purpose: Maximise user retention. Ethical issues: Accountability; Safety; Transparency. Reported consequences: Litigation;…",
-      "affected": "Google; Meta",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-mental-health",
-        "juris-california"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07729",
-      "title": "ChatGPT advises exec on how to fire company founders to avoid payout",
-      "date": "2025",
-      "year": 2025,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048.003",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-advises-exec-on-how-to-fire-company-founders-to-avoid-payout",
-      "description": "AIAAIC report: ChatGPT advises exec on how to fire company founders to avoid payout. System: ChatGPT. Technology: Generative AI. Purpose: Provide legal advice. Ethical issues: Accountability; Transparency. Reported consequences: Litigation; Fine/settlement.",
-      "affected": "OpenAI",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-delaware"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
       "id": "INC-03365",
       "title": "Welshman kills mother with sledgehammer after speaking to Discord AI bot",
       "date": "2025",
@@ -19220,7 +18983,7 @@
     },
     {
       "id": "INC-02346",
-      "title": "Australian bank employees train chatbot, are fired",
+      "title": "Australian Bank employees train chatbot, are fired",
       "date": "2025",
       "year": 2025,
       "severity": "Medium",
@@ -19237,7 +19000,7 @@
       ],
       "cve_ids": [],
       "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/australian-bank-employees-train-chatbot-are-fired",
-      "description": "AIAAIC report: Australian bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.",
+      "description": "AIAAIC report: Australian Bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.",
       "affected": "Commonwealth Bank of Australia",
       "tags": [
         "aiaaic",
@@ -43475,7 +43238,7 @@
       "tags": [
         "aiaaic",
         "aiaaic-sheet",
-        "sector-gambling",
+        "sector-gaming",
         "juris-uk"
       ],
       "quality_tier": "auto",
@@ -56881,8 +56644,7 @@
       "attack_vector": "other",
       "owasp_llm": [
         "LLM05",
-        "LLM06",
-        "LLM07"
+        "LLM06"
       ],
       "owasp_asi": [
         "ASI08",
@@ -56897,12 +56659,11 @@
         "AML.T0048",
         "AML.T0048.003",
         "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
+        "AML.T0053"
       ],
       "cve_ids": [],
       "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/uber-self-driving-car-pedestrian-fatality",
-      "description": "AIAAIC report: Uber self-driving car kills Arizona pedestrian. System: Automated Driving System. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Consent; Oversight;…",
+      "description": "AIAAIC report: Uber self-driving car kills Arizona pedestrian. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Safety. Reported consequences: Regulatory investigation;…",
       "affected": "Uber",
       "tags": [
         "aiaaic",
@@ -60864,6 +60625,243 @@
         "aiaaic-sheet",
         "sector-media/entertainment/sports/arts",
         "juris-australia"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07724",
+      "title": "Chinese AI actors spark personality rights controversy",
+      "date": "2026",
+      "year": 2026,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048.003",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chinese-ai-actors-spark-personality-rights-controversy",
+      "description": "AIAAIC report: Chinese AI actors spark personality rights controversy. Technology: Generative AI. Purpose: Create AI-generated performers. Ethical issues: Accountability; Consent; Employment; Transparency.",
+      "affected": "Youhug Media",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-china"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07725",
+      "title": "German TV star accuses husband of spreading deepfake porn images of her",
+      "date": "2024",
+      "year": 2024,
+      "severity": "Medium",
+      "attack_vector": "deepfake",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07",
+        "LLM09"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7",
+        "MEASURE-2.8"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056",
+        "AML.T0058"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/german-tv-star-accuses-husband-of-spreading-deepfake-porn-images-of-her",
+      "description": "AIAAIC report: German TV star accuses husband of spreading deepfake porn images of her. Technology: Deepfake. Purpose: Harass ex-wife. Ethical issues: Accountability; Authenticity/integrity; Privacy/surveillance; Safety; Transparency. Reported consequences: Legal…",
+      "affected": "Christian Ulmen",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-germany;-spain"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07726",
+      "title": "AI chatbots lure vulnerable gamblers to unlicensed betting websites",
+      "date": "2026",
+      "year": 2026,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/ai-chatbots-lure-vulnerable-gamblers-to-unlicensed-betting-websites",
+      "description": "AIAAIC report: AI chatbots lure vulnerable gamblers to unlicensed betting websites. System: ChatGPT; Claude; Copilot; Gemini; Grok; Le Chat; Meta AI. Technology: Generative AI. Purpose: Recommend online casinos. Ethical issues: Accountability; Safety; Transparency.",
+      "affected": "Anthropic; Google; Meta; Microsoft; Mistral; OpenAI; xAI",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-gambling",
+        "juris-austria;-belgium;-france"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07727",
+      "title": "ChatGPT accused of enabling Florida State University mass shooting",
+      "date": "2025",
+      "year": 2025,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-accused-of-enabling-florida-state-university-mass-shooting",
+      "description": "AIAAIC report: ChatGPT accused of enabling Florida State University mass shooting. System: ChatGPT. Technology: Generative AI. Purpose: Plan mass shooting. Ethical issues: Accountability; Alignment; Safety. Reported consequences: Litigation.",
+      "affected": "OpenAI",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-education",
+        "juris-florida"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07728",
+      "title": "Meta, YouTube found liable for addicting child to social media",
+      "date": "2012",
+      "year": 2012,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/meta-youtube-found-liable-for-addicting-child-to-social-media",
+      "description": "AIAAIC report: Meta, YouTube found liable for addicting child to social media. System: Explore. Technology: Machine learning; Recommendation algorithm. Purpose: Maximise user retention. Ethical issues: Accountability; Safety; Transparency. Reported consequences: Litigation;…",
+      "affected": "Google; Meta",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-mental-health",
+        "juris-california"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07729",
+      "title": "ChatGPT advises exec on how to fire company founders to avoid payout",
+      "date": "2025",
+      "year": 2025,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048.003",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-advises-exec-on-how-to-fire-company-founders-to-avoid-payout",
+      "description": "AIAAIC report: ChatGPT advises exec on how to fire company founders to avoid payout. System: ChatGPT. Technology: Generative AI. Purpose: Provide legal advice. Ethical issues: Accountability; Transparency. Reported consequences: Litigation; Fine/settlement.",
+      "affected": "OpenAI",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-delaware"
       ],
       "quality_tier": "auto",
       "corpus": "security"

--- a/docs/incident/INC-02346.md
+++ b/docs/incident/INC-02346.md
@@ -1,11 +1,11 @@
 ---
-title: "INC-02346 — Australian bank employees train chatbot, are fired"
+title: "INC-02346 — Australian Bank employees train chatbot, are fired"
 layout: incident
 permalink: /incident/INC-02346.html
 incident_id: INC-02346
 year: 2025
 severity: Medium
-description_preview: "AIAAIC report: Australian bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Repo"
+description_preview: "AIAAIC report: Australian Bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Repo"
 tags_str: "aiaaic, aiaaic-sheet, sector-banking/financial-services, juris-australia"
 ---
 
@@ -13,10 +13,10 @@ tags_str: "aiaaic, aiaaic-sheet, sector-banking/financial-services, juris-austra
 
 ### INC-02346  [↗](/incident/INC-02346.html)
 
-**Australian bank employees train chatbot, are fired**  
+**Australian Bank employees train chatbot, are fired**  
 _2025 · real-world · Severity: Medium_
 
-AIAAIC report: Australian bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.
+AIAAIC report: Australian Bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.
 
 **Affected:** Commonwealth Bank of Australia  
 **Attack vector:** `other`  

--- a/docs/incident/INC-05503.md
+++ b/docs/incident/INC-05503.md
@@ -6,7 +6,7 @@ incident_id: INC-05503
 year: 2021
 severity: Critical
 description_preview: "AIAAIC report: Betfair algorithm misses gambling addict red flags. Technology: Machine learning. Purpose: Detect customer risk; Track customer data. Ethical issues: Accountability; Accuracy/reliabilit"
-tags_str: "aiaaic, aiaaic-sheet, sector-gambling, juris-uk"
+tags_str: "aiaaic, aiaaic-sheet, sector-gaming, juris-uk"
 ---
 
 <div class="incident-anchor" id="inc-05503" markdown="1">
@@ -29,7 +29,7 @@ AIAAIC report: Betfair algorithm misses gambling addict red flags. Technology: M
 **References:**
 - [AIAAIC entry](https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/algorithm-misses-gambling-addict-red-flags) _(report)_
 
-**Tags:** `aiaaic`, `aiaaic-sheet`, `sector-gambling`, `juris-uk`
+**Tags:** `aiaaic`, `aiaaic-sheet`, `sector-gaming`, `juris-uk`
 
 </div>
 

--- a/docs/incident/INC-07353.md
+++ b/docs/incident/INC-07353.md
@@ -5,7 +5,7 @@ permalink: /incident/INC-07353.html
 incident_id: INC-07353
 year: 2018
 severity: Critical
-description_preview: "AIAAIC report: Uber self-driving car kills Arizona pedestrian. System: Automated Driving System. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Et"
+description_preview: "AIAAIC report: Uber self-driving car kills Arizona pedestrian. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accu"
 tags_str: "aiaaic, aiaaic-sheet, sector-automotive, juris-usa"
 ---
 
@@ -16,15 +16,15 @@ tags_str: "aiaaic, aiaaic-sheet, sector-automotive, juris-usa"
 **Uber self-driving car kills Arizona pedestrian**  
 _2018 · real-world · Severity: Critical_
 
-AIAAIC report: Uber self-driving car kills Arizona pedestrian. System: Automated Driving System. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Consent; Oversight; Safety; Transparency. Reported consequences: Regulatory investigation; Litigation; Settlement/fine. Response: System suspension.
+AIAAIC report: Uber self-driving car kills Arizona pedestrian. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Safety. Reported consequences: Regulatory investigation; Litigation. Response: System suspension.
 
 **Affected:** Uber  
 **Attack vector:** `other`  
 
-**OWASP LLM Top 10:** `LLM05`, `LLM06`, `LLM07`  
+**OWASP LLM Top 10:** `LLM05`, `LLM06`  
 **OWASP Agentic (ASI):** `ASI08`, `ASI09`  
 **NIST AI RMF:** `MANAGE-4.1`, `MAP-3.5`, `MEASURE-2.7`  
-**MITRE ATLAS:** `AML.T0048`, `AML.T0048.003`, `AML.T0050`, `AML.T0053`, `AML.T0056`  
+**MITRE ATLAS:** `AML.T0048`, `AML.T0048.003`, `AML.T0050`, `AML.T0053`  
 
 **References:**
 - [AIAAIC entry](https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/uber-self-driving-car-pedestrian-fatality) _(report)_

--- a/docs/incidents/2018.md
+++ b/docs/incidents/2018.md
@@ -2384,15 +2384,15 @@ AIAAIC report: Uber ID algorithm suspends transgender drivers. System: Real-Time
 **Uber self-driving car kills Arizona pedestrian**  
 _2018 · real-world · Severity: Critical_
 
-AIAAIC report: Uber self-driving car kills Arizona pedestrian. System: Automated Driving System. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Consent; Oversight; Safety; Transparency. Reported consequences: Regulatory investigation; Litigation; Settlement/fine. Response: System suspension.
+AIAAIC report: Uber self-driving car kills Arizona pedestrian. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Safety. Reported consequences: Regulatory investigation; Litigation. Response: System suspension.
 
 **Affected:** Uber  
 **Attack vector:** `other`  
 
-**OWASP LLM Top 10:** `LLM05`, `LLM06`, `LLM07`  
+**OWASP LLM Top 10:** `LLM05`, `LLM06`  
 **OWASP Agentic (ASI):** `ASI08`, `ASI09`  
 **NIST AI RMF:** `MANAGE-4.1`, `MAP-3.5`, `MEASURE-2.7`  
-**MITRE ATLAS:** `AML.T0048`, `AML.T0048.003`, `AML.T0050`, `AML.T0053`, `AML.T0056`  
+**MITRE ATLAS:** `AML.T0048`, `AML.T0048.003`, `AML.T0050`, `AML.T0053`  
 
 **References:**
 - [AIAAIC entry](https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/uber-self-driving-car-pedestrian-fatality) _(report)_

--- a/docs/incidents/2021.md
+++ b/docs/incidents/2021.md
@@ -19096,7 +19096,7 @@ AIAAIC report: Betfair algorithm misses gambling addict red flags. Technology: M
 **References:**
 - [AIAAIC entry](https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/algorithm-misses-gambling-addict-red-flags) _(report)_
 
-**Tags:** `aiaaic`, `aiaaic-sheet`, `sector-gambling`, `juris-uk`
+**Tags:** `aiaaic`, `aiaaic-sheet`, `sector-gaming`, `juris-uk`
 
 </div>
 

--- a/docs/incidents/2025.md
+++ b/docs/incidents/2025.md
@@ -27910,10 +27910,10 @@ AIAAIC report: Australian activist Caitlin Roper targeted with AI-generated viol
 
 ### INC-02346  [↗](/incident/INC-02346.html)
 
-**Australian bank employees train chatbot, are fired**  
+**Australian Bank employees train chatbot, are fired**  
 _2025 · real-world · Severity: Medium_
 
-AIAAIC report: Australian bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.
+AIAAIC report: Australian Bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.
 
 **Affected:** Commonwealth Bank of Australia  
 **Attack vector:** `other`  

--- a/ingest/aiaaic_sheet_incidents.json
+++ b/ingest/aiaaic_sheet_incidents.json
@@ -46389,5 +46389,237 @@
       "sector-media/entertainment/sports/arts",
       "juris-australia"
     ]
+  },
+  {
+    "source_id": "AIAAIC2263",
+    "title": "Chinese AI actors spark personality rights controversy",
+    "date": "2026",
+    "year": 2026,
+    "category": "real-world",
+    "description": "AIAAIC report: Chinese AI actors spark personality rights controversy. Technology: Generative AI. Purpose: Create AI-generated performers. Ethical issues: Accountability; Consent; Employment; Transparency.",
+    "attack_vector": "other",
+    "affected": "Youhug Media",
+    "severity": "Medium",
+    "owasp_llm": [
+      "LLM06",
+      "LLM07"
+    ],
+    "owasp_asi": [
+      "ASI09"
+    ],
+    "mitre_atlas": [
+      "AML.T0048.003",
+      "AML.T0053",
+      "AML.T0056"
+    ],
+    "references": [
+      {
+        "title": "AIAAIC entry",
+        "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chinese-ai-actors-spark-personality-rights-controversy",
+        "type": "report"
+      }
+    ],
+    "tags": [
+      "aiaaic",
+      "aiaaic-sheet",
+      "sector-media/entertainment/sports/arts",
+      "juris-china"
+    ]
+  },
+  {
+    "source_id": "AIAAIC2262",
+    "title": "German TV star accuses husband of spreading deepfake porn images of her",
+    "date": "2024",
+    "year": 2024,
+    "category": "real-world",
+    "description": "AIAAIC report: German TV star accuses husband of spreading deepfake porn images of her. Technology: Deepfake. Purpose: Harass ex-wife. Ethical issues: Accountability; Authenticity/integrity; Privacy/surveillance; Safety; Transparency. Reported consequences: Legal complaint/investigation; Legislation introduction/update.",
+    "attack_vector": "deepfake",
+    "affected": "Christian Ulmen",
+    "severity": "Medium",
+    "owasp_llm": [
+      "LLM05",
+      "LLM06",
+      "LLM07",
+      "LLM09"
+    ],
+    "owasp_asi": [
+      "ASI08",
+      "ASI09"
+    ],
+    "mitre_atlas": [
+      "AML.T0048",
+      "AML.T0048.003",
+      "AML.T0050",
+      "AML.T0053",
+      "AML.T0056",
+      "AML.T0058"
+    ],
+    "references": [
+      {
+        "title": "AIAAIC entry",
+        "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/german-tv-star-accuses-husband-of-spreading-deepfake-porn-images-of-her",
+        "type": "report"
+      }
+    ],
+    "tags": [
+      "aiaaic",
+      "aiaaic-sheet",
+      "sector-media/entertainment/sports/arts",
+      "juris-germany;-spain"
+    ]
+  },
+  {
+    "source_id": "AIAAIC2261",
+    "title": "AI chatbots lure vulnerable gamblers to unlicensed betting websites",
+    "date": "2026",
+    "year": 2026,
+    "category": "real-world",
+    "description": "AIAAIC report: AI chatbots lure vulnerable gamblers to unlicensed betting websites. System: ChatGPT; Claude; Copilot; Gemini; Grok; Le Chat; Meta AI. Technology: Generative AI. Purpose: Recommend online casinos. Ethical issues: Accountability; Safety; Transparency.",
+    "attack_vector": "other",
+    "affected": "Anthropic; Google; Meta; Microsoft; Mistral; OpenAI; xAI",
+    "severity": "Medium",
+    "owasp_llm": [
+      "LLM05",
+      "LLM06",
+      "LLM07"
+    ],
+    "owasp_asi": [
+      "ASI08",
+      "ASI09"
+    ],
+    "mitre_atlas": [
+      "AML.T0048",
+      "AML.T0048.003",
+      "AML.T0050",
+      "AML.T0053",
+      "AML.T0056"
+    ],
+    "references": [
+      {
+        "title": "AIAAIC entry",
+        "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/ai-chatbots-lure-vulnerable-gamblers-to-unlicensed-betting-websites",
+        "type": "report"
+      }
+    ],
+    "tags": [
+      "aiaaic",
+      "aiaaic-sheet",
+      "sector-gambling",
+      "juris-austria;-belgium;-france"
+    ]
+  },
+  {
+    "source_id": "AIAAIC2260",
+    "title": "ChatGPT accused of enabling Florida State University mass shooting",
+    "date": "2025",
+    "year": 2025,
+    "category": "real-world",
+    "description": "AIAAIC report: ChatGPT accused of enabling Florida State University mass shooting. System: ChatGPT. Technology: Generative AI. Purpose: Plan mass shooting. Ethical issues: Accountability; Alignment; Safety. Reported consequences: Litigation.",
+    "attack_vector": "other",
+    "affected": "OpenAI",
+    "severity": "Medium",
+    "owasp_llm": [
+      "LLM05",
+      "LLM06"
+    ],
+    "owasp_asi": [
+      "ASI08",
+      "ASI09"
+    ],
+    "mitre_atlas": [
+      "AML.T0048",
+      "AML.T0048.003",
+      "AML.T0050",
+      "AML.T0053"
+    ],
+    "references": [
+      {
+        "title": "AIAAIC entry",
+        "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-accused-of-enabling-florida-state-university-mass-shooting",
+        "type": "report"
+      }
+    ],
+    "tags": [
+      "aiaaic",
+      "aiaaic-sheet",
+      "sector-education",
+      "juris-florida"
+    ]
+  },
+  {
+    "source_id": "AIAAIC2259",
+    "title": "Meta, YouTube found liable for addicting child to social media",
+    "date": "2012",
+    "year": 2012,
+    "category": "real-world",
+    "description": "AIAAIC report: Meta, YouTube found liable for addicting child to social media. System: Explore. Technology: Machine learning; Recommendation algorithm. Purpose: Maximise user retention. Ethical issues: Accountability; Safety; Transparency. Reported consequences: Litigation; Fine/settlement.",
+    "attack_vector": "other",
+    "affected": "Google; Meta",
+    "severity": "Medium",
+    "owasp_llm": [
+      "LLM05",
+      "LLM06",
+      "LLM07"
+    ],
+    "owasp_asi": [
+      "ASI08",
+      "ASI09"
+    ],
+    "mitre_atlas": [
+      "AML.T0048",
+      "AML.T0048.003",
+      "AML.T0050",
+      "AML.T0053",
+      "AML.T0056"
+    ],
+    "references": [
+      {
+        "title": "AIAAIC entry",
+        "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/meta-youtube-found-liable-for-addicting-child-to-social-media",
+        "type": "report"
+      }
+    ],
+    "tags": [
+      "aiaaic",
+      "aiaaic-sheet",
+      "sector-mental-health",
+      "juris-california"
+    ]
+  },
+  {
+    "source_id": "AIAAIC2258",
+    "title": "ChatGPT advises exec on how to fire company founders to avoid payout",
+    "date": "2025",
+    "year": 2025,
+    "category": "real-world",
+    "description": "AIAAIC report: ChatGPT advises exec on how to fire company founders to avoid payout. System: ChatGPT. Technology: Generative AI. Purpose: Provide legal advice. Ethical issues: Accountability; Transparency. Reported consequences: Litigation; Fine/settlement.",
+    "attack_vector": "other",
+    "affected": "OpenAI",
+    "severity": "Medium",
+    "owasp_llm": [
+      "LLM06",
+      "LLM07"
+    ],
+    "owasp_asi": [
+      "ASI09"
+    ],
+    "mitre_atlas": [
+      "AML.T0048.003",
+      "AML.T0053",
+      "AML.T0056"
+    ],
+    "references": [
+      {
+        "title": "AIAAIC entry",
+        "url": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-advises-exec-on-how-to-fire-company-founders-to-avoid-payout",
+        "type": "report"
+      }
+    ],
+    "tags": [
+      "aiaaic",
+      "aiaaic-sheet",
+      "sector-media/entertainment/sports/arts",
+      "juris-delaware"
+    ]
   }
 ]

--- a/src/genai_incidents/data/incidents.min.json
+++ b/src/genai_incidents/data/incidents.min.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generated": "2026-05-26",
+  "generated": "2026-05-29",
   "incident_count": 7720,
   "incidents": [
     {
@@ -12533,243 +12533,6 @@
       "corpus": "security"
     },
     {
-      "id": "INC-07724",
-      "title": "Chinese AI actors spark personality rights controversy",
-      "date": "2026",
-      "year": 2026,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048.003",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chinese-ai-actors-spark-personality-rights-controversy",
-      "description": "AIAAIC report: Chinese AI actors spark personality rights controversy. Technology: Generative AI. Purpose: Create AI-generated performers. Ethical issues: Accountability; Consent; Employment; Transparency.",
-      "affected": "Youhug Media",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-china"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07725",
-      "title": "German TV star accuses husband of spreading deepfake porn images of her",
-      "date": "2024",
-      "year": 2024,
-      "severity": "Medium",
-      "attack_vector": "deepfake",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07",
-        "LLM09"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7",
-        "MEASURE-2.8"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056",
-        "AML.T0058"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/german-tv-star-accuses-husband-of-spreading-deepfake-porn-images-of-her",
-      "description": "AIAAIC report: German TV star accuses husband of spreading deepfake porn images of her. Technology: Deepfake. Purpose: Harass ex-wife. Ethical issues: Accountability; Authenticity/integrity; Privacy/surveillance; Safety; Transparency. Reported consequences: Legal…",
-      "affected": "Christian Ulmen",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-germany;-spain"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07726",
-      "title": "AI chatbots lure vulnerable gamblers to unlicensed betting websites",
-      "date": "2026",
-      "year": 2026,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/ai-chatbots-lure-vulnerable-gamblers-to-unlicensed-betting-websites",
-      "description": "AIAAIC report: AI chatbots lure vulnerable gamblers to unlicensed betting websites. System: ChatGPT; Claude; Copilot; Gemini; Grok; Le Chat; Meta AI. Technology: Generative AI. Purpose: Recommend online casinos. Ethical issues: Accountability; Safety; Transparency.",
-      "affected": "Anthropic; Google; Meta; Microsoft; Mistral; OpenAI; xAI",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-gambling",
-        "juris-austria;-belgium;-france"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07727",
-      "title": "ChatGPT accused of enabling Florida State University mass shooting",
-      "date": "2025",
-      "year": 2025,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-accused-of-enabling-florida-state-university-mass-shooting",
-      "description": "AIAAIC report: ChatGPT accused of enabling Florida State University mass shooting. System: ChatGPT. Technology: Generative AI. Purpose: Plan mass shooting. Ethical issues: Accountability; Alignment; Safety. Reported consequences: Litigation.",
-      "affected": "OpenAI",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-education",
-        "juris-florida"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07728",
-      "title": "Meta, YouTube found liable for addicting child to social media",
-      "date": "2012",
-      "year": 2012,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM05",
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI08",
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MANAGE-4.1",
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048",
-        "AML.T0048.003",
-        "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/meta-youtube-found-liable-for-addicting-child-to-social-media",
-      "description": "AIAAIC report: Meta, YouTube found liable for addicting child to social media. System: Explore. Technology: Machine learning; Recommendation algorithm. Purpose: Maximise user retention. Ethical issues: Accountability; Safety; Transparency. Reported consequences: Litigation;…",
-      "affected": "Google; Meta",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-mental-health",
-        "juris-california"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
-      "id": "INC-07729",
-      "title": "ChatGPT advises exec on how to fire company founders to avoid payout",
-      "date": "2025",
-      "year": 2025,
-      "severity": "Medium",
-      "attack_vector": "other",
-      "owasp_llm": [
-        "LLM06",
-        "LLM07"
-      ],
-      "owasp_asi": [
-        "ASI09"
-      ],
-      "nist_ai_rmf": [
-        "MAP-3.5",
-        "MEASURE-2.7"
-      ],
-      "mitre_atlas": [
-        "AML.T0048.003",
-        "AML.T0053",
-        "AML.T0056"
-      ],
-      "cve_ids": [],
-      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-advises-exec-on-how-to-fire-company-founders-to-avoid-payout",
-      "description": "AIAAIC report: ChatGPT advises exec on how to fire company founders to avoid payout. System: ChatGPT. Technology: Generative AI. Purpose: Provide legal advice. Ethical issues: Accountability; Transparency. Reported consequences: Litigation; Fine/settlement.",
-      "affected": "OpenAI",
-      "tags": [
-        "aiaaic",
-        "aiaaic-sheet",
-        "sector-media/entertainment/sports/arts",
-        "juris-delaware"
-      ],
-      "quality_tier": "auto",
-      "corpus": "security"
-    },
-    {
       "id": "INC-03365",
       "title": "Welshman kills mother with sledgehammer after speaking to Discord AI bot",
       "date": "2025",
@@ -19220,7 +18983,7 @@
     },
     {
       "id": "INC-02346",
-      "title": "Australian bank employees train chatbot, are fired",
+      "title": "Australian Bank employees train chatbot, are fired",
       "date": "2025",
       "year": 2025,
       "severity": "Medium",
@@ -19237,7 +19000,7 @@
       ],
       "cve_ids": [],
       "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/australian-bank-employees-train-chatbot-are-fired",
-      "description": "AIAAIC report: Australian bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.",
+      "description": "AIAAIC report: Australian Bank employees train chatbot, are fired. System: Bumblebee. Technology: Generative AI. Purpose: Train chatbot. Ethical issues: Employment/labour; Fairness; Transparency. Reported consequences: Regulatory investigation.",
       "affected": "Commonwealth Bank of Australia",
       "tags": [
         "aiaaic",
@@ -43475,7 +43238,7 @@
       "tags": [
         "aiaaic",
         "aiaaic-sheet",
-        "sector-gambling",
+        "sector-gaming",
         "juris-uk"
       ],
       "quality_tier": "auto",
@@ -56881,8 +56644,7 @@
       "attack_vector": "other",
       "owasp_llm": [
         "LLM05",
-        "LLM06",
-        "LLM07"
+        "LLM06"
       ],
       "owasp_asi": [
         "ASI08",
@@ -56897,12 +56659,11 @@
         "AML.T0048",
         "AML.T0048.003",
         "AML.T0050",
-        "AML.T0053",
-        "AML.T0056"
+        "AML.T0053"
       ],
       "cve_ids": [],
       "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/uber-self-driving-car-pedestrian-fatality",
-      "description": "AIAAIC report: Uber self-driving car kills Arizona pedestrian. System: Automated Driving System. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Consent; Oversight;…",
+      "description": "AIAAIC report: Uber self-driving car kills Arizona pedestrian. Technology: Self-driving system; Computer vision. Purpose: Automate steering, acceleration, braking. Ethical issues: Accountability; Accuracy/reliability; Safety. Reported consequences: Regulatory investigation;…",
       "affected": "Uber",
       "tags": [
         "aiaaic",
@@ -60864,6 +60625,243 @@
         "aiaaic-sheet",
         "sector-media/entertainment/sports/arts",
         "juris-australia"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07724",
+      "title": "Chinese AI actors spark personality rights controversy",
+      "date": "2026",
+      "year": 2026,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048.003",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chinese-ai-actors-spark-personality-rights-controversy",
+      "description": "AIAAIC report: Chinese AI actors spark personality rights controversy. Technology: Generative AI. Purpose: Create AI-generated performers. Ethical issues: Accountability; Consent; Employment; Transparency.",
+      "affected": "Youhug Media",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-china"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07725",
+      "title": "German TV star accuses husband of spreading deepfake porn images of her",
+      "date": "2024",
+      "year": 2024,
+      "severity": "Medium",
+      "attack_vector": "deepfake",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07",
+        "LLM09"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7",
+        "MEASURE-2.8"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056",
+        "AML.T0058"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/german-tv-star-accuses-husband-of-spreading-deepfake-porn-images-of-her",
+      "description": "AIAAIC report: German TV star accuses husband of spreading deepfake porn images of her. Technology: Deepfake. Purpose: Harass ex-wife. Ethical issues: Accountability; Authenticity/integrity; Privacy/surveillance; Safety; Transparency. Reported consequences: Legal…",
+      "affected": "Christian Ulmen",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-germany;-spain"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07726",
+      "title": "AI chatbots lure vulnerable gamblers to unlicensed betting websites",
+      "date": "2026",
+      "year": 2026,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/ai-chatbots-lure-vulnerable-gamblers-to-unlicensed-betting-websites",
+      "description": "AIAAIC report: AI chatbots lure vulnerable gamblers to unlicensed betting websites. System: ChatGPT; Claude; Copilot; Gemini; Grok; Le Chat; Meta AI. Technology: Generative AI. Purpose: Recommend online casinos. Ethical issues: Accountability; Safety; Transparency.",
+      "affected": "Anthropic; Google; Meta; Microsoft; Mistral; OpenAI; xAI",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-gambling",
+        "juris-austria;-belgium;-france"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07727",
+      "title": "ChatGPT accused of enabling Florida State University mass shooting",
+      "date": "2025",
+      "year": 2025,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-accused-of-enabling-florida-state-university-mass-shooting",
+      "description": "AIAAIC report: ChatGPT accused of enabling Florida State University mass shooting. System: ChatGPT. Technology: Generative AI. Purpose: Plan mass shooting. Ethical issues: Accountability; Alignment; Safety. Reported consequences: Litigation.",
+      "affected": "OpenAI",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-education",
+        "juris-florida"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07728",
+      "title": "Meta, YouTube found liable for addicting child to social media",
+      "date": "2012",
+      "year": 2012,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM05",
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI08",
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MANAGE-4.1",
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048",
+        "AML.T0048.003",
+        "AML.T0050",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/meta-youtube-found-liable-for-addicting-child-to-social-media",
+      "description": "AIAAIC report: Meta, YouTube found liable for addicting child to social media. System: Explore. Technology: Machine learning; Recommendation algorithm. Purpose: Maximise user retention. Ethical issues: Accountability; Safety; Transparency. Reported consequences: Litigation;…",
+      "affected": "Google; Meta",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-mental-health",
+        "juris-california"
+      ],
+      "quality_tier": "auto",
+      "corpus": "security"
+    },
+    {
+      "id": "INC-07729",
+      "title": "ChatGPT advises exec on how to fire company founders to avoid payout",
+      "date": "2025",
+      "year": 2025,
+      "severity": "Medium",
+      "attack_vector": "other",
+      "owasp_llm": [
+        "LLM06",
+        "LLM07"
+      ],
+      "owasp_asi": [
+        "ASI09"
+      ],
+      "nist_ai_rmf": [
+        "MAP-3.5",
+        "MEASURE-2.7"
+      ],
+      "mitre_atlas": [
+        "AML.T0048.003",
+        "AML.T0053",
+        "AML.T0056"
+      ],
+      "cve_ids": [],
+      "primary_reference": "https://www.aiaaic.org/aiaaic-repository/ai-algorithmic-and-automation-incidents/chatgpt-advises-exec-on-how-to-fire-company-founders-to-avoid-payout",
+      "description": "AIAAIC report: ChatGPT advises exec on how to fire company founders to avoid payout. System: ChatGPT. Technology: Generative AI. Purpose: Provide legal advice. Ethical issues: Accountability; Transparency. Reported consequences: Litigation; Fine/settlement.",
+      "affected": "OpenAI",
+      "tags": [
+        "aiaaic",
+        "aiaaic-sheet",
+        "sector-media/entertainment/sports/arts",
+        "juris-delaware"
       ],
       "quality_tier": "auto",
       "corpus": "security"


### PR DESCRIPTION
## Problem

The `validate` workflow's **"Re-render INCIDENTS.md and ensure no drift"** step has been failing on every push to `main` since the 2026-05-26 `build: regenerate all outputs after classifier improvement` commit. The committed dataset had drifted out of sync with the ingest sources, so re-merging from the committed inputs produced different output than what's checked in.

## Root cause (two independent issues)

1. **6 incidents missing from the ingest source.** `AIAAIC2258`–`AIAAIC2263` (→ `INC-07724`–`INC-07729`) existed in `data/incidents.json` but **not** in `ingest/aiaaic_sheet_incidents.json` (which stopped at `AIAAIC2257`). Re-merging from the committed ingest therefore *deleted* them. The regenerated outputs had been committed without the updated ingest file.
2. **Stale title/description text.** A few AIAAIC titles in the committed outputs lagged the current ingest (e.g. `Australian bank` → `Australian Bank`, on INC-02346 / INC-05503 / INC-07353).

## Fix

- Restored the 6 records to `ingest/aiaaic_sheet_incidents.json` (reconstructed from their committed form; the merge re-derives `nist_ai_rmf`/`mitre_atlas` and reuses the stable `INC-*` IDs and timestamps by `source_id`).
- Regenerated all pipeline outputs (`incidents.json`, `incidents.min.json`, `INCIDENTS.md`, per-incident pages, year shards, charts, packaged data).

## Impact
- **No incidents added or removed** — count stays **7,720**.
- No taxonomy mass-shift. Net change: the 6 records reappear in sorted position, ~6 records pick up fresher source text, and `updated` timestamps reconcile.
- `data/legacy_consolidated.json` is intentionally **not** touched — it's an intermediate artifact CI regenerates fresh and does not drift-check.

## Verification
- ✅ `validate.py` → 7,720/7,720 valid
- ✅ **CI drift check reproduced locally → zero drift** (regenerating from the committed state produces no changes)
- ✅ Pipeline is **idempotent** — a second run yields a byte-identical `incidents.json`
- ✅ `pytest` → 62 passed

This should turn the `validate` workflow green again across the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)