### PR TITLE
ci: bump checkout@v6 + setup-python@v6 for Node 24

### DIFF
--- a/.github/workflows/auto-refresh.yml
+++ b/.github/workflows/auto-refresh.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Mirror data file into docs/data/
         run: |
           mkdir -p docs/data

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,8 @@ jobs:
       id-token: write   # trusted publishing — no API tokens
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,9 +9,9 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip


### PR DESCRIPTION
## Summary

GitHub Actions flagged `actions/checkout@v4` and `actions/setup-python@v5` as running on the **deprecated Node 20 runtime**:

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting **June 16th, 2026**. Node.js 20 will be removed from the runner on **September 16th, 2026**.

Bumped both to their current Node 24 majors (`checkout@v6`, `setup-python@v6`) across all four workflows: `auto-refresh.yml`, `pages.yml`, `publish.yml`, `validate.yml`.

## Compatibility
The only breaking change in either v6 release is the Node 24 upgrade itself (requires runner ≥ v2.327.1, which GitHub-hosted runners satisfy). The inputs these workflows use — `python-version`, `cache: pip`, and default checkout behavior — are unchanged.

Other actions in the workflows (`configure-pages`, `deploy-pages`, `jekyll-build-pages`, `upload-pages-artifact`, `gh-action-pypi-publish`) were **not** in the deprecation annotation and are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)