### PR TITLE
feat(curation): review security-relevant Medium AIAAIC batch (severity + classification fixes)

### DIFF
--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -4,7 +4,7 @@ Single source of truth for GenAI and agentic AI security incidents.
 Each entry is mapped to **OWASP LLM Top 10 (2025)**, **OWASP Agentic Top 10 (ASI)**, **NIST AI RMF**, and **MITRE ATLAS**.
 
 - **Version:** 2.0.0
-- **Generated:** 2026-05-29
+- **Generated:** 2026-05-30
 - **Total incidents:** **7,720**
 - **Date range:** 1983 – 2026
 - **With CVE:** 1,654
@@ -32,8 +32,8 @@ Auto-generated from the current dataset. SVGs live under [`docs/charts/`](docs/c
 | Severity | Count |
 |---|---:|
 | Critical | 1,486 |
-| High | 2,877 |
-| Medium | 3,221 |
+| High | 2,884 |
+| Medium | 3,214 |
 | Low | 136 |
 
 ### Incidents per Year
@@ -3437,7 +3437,7 @@ All **7,720** incidents in a single table, newest-first. Each `INC-*****` link o
 | 3,307 | 2025 | [`INC-02947`](docs/incidents/2025.md#inc-02947) | Neo humanoid robot sparks privacy fears and autonomy doubts | Medium | LLM02, LLM03, LLM05, LLM07, LLM09 | ASI02, ASI03, ASI08, ASI09 |  |
 | 3,308 | 2025 | [`INC-02949`](docs/incidents/2025.md#inc-02949) | Neuroscientists sue Apple for illegally using their books to train AI models | Medium | LLM06, LLM07 | ASI09 |  |
 | 3,309 | 2025 | [`INC-02961`](docs/incidents/2025.md#inc-02961) | North Korean hackers use ChatGPT to make deepfake military IDs | Medium | LLM02, LLM03, LLM09 | ASI02, ASI03, ASI09 |  |
-| 3,310 | 2025 | [`INC-02967`](docs/incidents/2025.md#inc-02967) | Nude detection dataset contains child sexual abuse imagery | Medium | LLM05, LLM06, LLM07 | ASI08, ASI09 |  |
+| 3,310 | 2025 | [`INC-02967`](docs/incidents/2025.md#inc-02967) | Nude detection dataset contains child sexual abuse imagery | High | LLM05, LLM06, LLM07 | ASI08, ASI09 |  |
 | 3,311 | 2025 | [`INC-02968`](docs/incidents/2025.md#inc-02968) | NVIDIA Container Toolkit TOCTOU (CVE-2025-23359) | Critical | LLM03 |  |  |
 | 3,312 | 2025 | [`INC-02991`](docs/incidents/2025.md#inc-02991) | OpenAI accused of using Netflix shows to train Sora AI video tool | Medium | LLM06, LLM07 | ASI09 |  |
 | 3,313 | 2025 | [`INC-02992`](docs/incidents/2025.md#inc-02992) | OpenAI accused of violating Studio Ghibli copyright | Medium | LLM06, LLM07 | ASI09 |  |
@@ -4189,7 +4189,7 @@ All **7,720** incidents in a single table, newest-first. Each `INC-*****` link o
 | 4,059 | 2024 | [`INC-03461`](docs/incidents/2024.md#inc-03461) | AI detector falsely accuses autistic student of cheating | Medium | LLM06, LLM07 | ASI09 |  |
 | 4,060 | 2024 | [`INC-03463`](docs/incidents/2024.md#inc-03463) | AI generates visuals for Wizards of the Coast marketing promotion | Medium | LLM07 |  |  |
 | 4,061 | 2024 | [`INC-03464`](docs/incidents/2024.md#inc-03464) | AI hiring chatbot hack violates applicants' privacy | Medium | LLM02, LLM03 | ASI02, ASI03 |  |
-| 4,062 | 2024 | [`INC-03466`](docs/incidents/2024.md#inc-03466) | AI malware scam "destroys" Disney employee's life | Medium | LLM02, LLM03 | ASI02, ASI03 |  |
+| 4,062 | 2024 | [`INC-03466`](docs/incidents/2024.md#inc-03466) | AI malware scam "destroys" Disney employee's life | High | LLM02, LLM03 | ASI02, ASI03 |  |
 | 4,063 | 2024 | [`INC-03467`](docs/incidents/2024.md#inc-03467) | AI models found to generate inaccurate and untrue election info | Medium | LLM09 |  |  |
 | 4,064 | 2024 | [`INC-03469`](docs/incidents/2024.md#inc-03469) | AI news site falsely accuses US attorney of murder | Medium | LLM09 |  |  |
 | 4,065 | 2024 | [`INC-03471`](docs/incidents/2024.md#inc-03471) | AI nudification bots swamp Telegram | Critical | LLM05, LLM06, LLM07, LLM09 | ASI08, ASI09 |  |
@@ -4934,7 +4934,7 @@ All **7,720** incidents in a single table, newest-first. Each `INC-*****` link o
 | 4,804 | 2023 | [`INC-04567`](docs/incidents/2023.md#inc-04567) | Chinese scammer uses AI to defraud 'friend' of USD 622,000 | Medium | LLM02, LLM03 | ASI02, ASI03 |  |
 | 4,805 | 2023 | [`INC-04568`](docs/incidents/2023.md#inc-04568) | Chinese voice actor sues AI companies for using her voice without consent | Medium | LLM06, LLM07 | ASI09 |  |
 | 4,806 | 2023 | [`INC-04570`](docs/incidents/2023.md#inc-04570) | Cigna PxDx accused of accelerating health insurance claim denials | Medium | LLM06, LLM07 | ASI09 |  |
-| 4,807 | 2023 | [`INC-04571`](docs/incidents/2023.md#inc-04571) | CivitAI accused of generating synthetic 'child pornography' images | Medium | LLM05, LLM07 | ASI08 |  |
+| 4,807 | 2023 | [`INC-04571`](docs/incidents/2023.md#inc-04571) | CivitAI accused of generating synthetic 'child pornography' images | High | LLM05, LLM07 | ASI08 |  |
 | 4,808 | 2023 | [`INC-04576`](docs/incidents/2023.md#inc-04576) | Clearview AI tests live facial-recognition cameras and AR glasses | High | LLM02 | ASI03 |  |
 | 4,809 | 2023 | [`INC-04579`](docs/incidents/2023.md#inc-04579) | Corruption doc incorporating Tom Cruise deepfake attacks IOC | Medium | LLM09 | ASI09 |  |
 | 4,810 | 2023 | [`INC-04580`](docs/incidents/2023.md#inc-04580) | Couple assaulted in 'Hell Run' recommended by Google Maps | Medium | LLM05 | ASI08 |  |
@@ -6177,7 +6177,7 @@ All **7,720** incidents in a single table, newest-first. Each `INC-*****` link o
 | 6,047 | 2021 | [`INC-05370`](docs/incidents/2021.md#inc-05370) | 4 Little Trees (4LT) student emotion recognition system prompts criticism | Medium | LLM07 |  |  |
 | 6,048 | 2021 | [`INC-05373`](docs/incidents/2021.md#inc-05373) | Adam Toledo killed by Chicago police using ShotSpotter | Critical | LLM05, LLM06, LLM07 | ASI08, ASI09 |  |
 | 6,049 | 2021 | [`INC-05375`](docs/incidents/2021.md#inc-05375) | Adobe Project Morpheus slammed for deepfake uses | Medium | LLM09 | ASI09 |  |
-| 6,050 | 2021 | [`INC-05382`](docs/incidents/2021.md#inc-05382) | AI Dungeon offensive speech filter upgrade generates child porn | Medium | LLM05 | ASI08 |  |
+| 6,050 | 2021 | [`INC-05382`](docs/incidents/2021.md#inc-05382) | AI Dungeon offensive speech filter upgrade generates child porn | High | LLM05 | ASI08 |  |
 | 6,051 | 2021 | [`INC-05437`](docs/incidents/2021.md#inc-05437) | AI-powered sinus surgery tool accused of repeatedly seriously injuring patients | Medium | LLM05, LLM06, LLM07 | ASI08, ASI09 |  |
 | 6,052 | 2021 | [`INC-05442`](docs/incidents/2021.md#inc-05442) | AI-powered Uyghur emotion detection system prompts rights concerns | Medium |  |  |  |
 | 6,053 | 2021 | [`INC-05450`](docs/incidents/2021.md#inc-05450) | Amazon accused of "unfairly" firing Flex delivery drivers by algorithm | Medium | LLM06, LLM07 | ASI09 |  |
@@ -6328,7 +6328,7 @@ All **7,720** incidents in a single table, newest-first. Each `INC-*****` link o
 | 6,198 | 2021 | [`INC-06167`](docs/incidents/2021.md#inc-06167) | US mortgage approval algorithm more likely to reject people of colour | Medium | LLM06 | ASI09 |  |
 | 6,199 | 2021 | [`INC-06169`](docs/incidents/2021.md#inc-06169) | US Postal Inspection Service covertly monitors justice protestors | Medium | LLM06, LLM07 | ASI09 |  |
 | 6,200 | 2021 | [`INC-06174`](docs/incidents/2021.md#inc-06174) | Verkada facial recognition camera hack prompts security, ethics concerns | Medium | LLM02, LLM03, LLM07 | ASI02, ASI03 |  |
-| 6,201 | 2021 | [`INC-06178`](docs/incidents/2021.md#inc-06178) | VRChat users’ avatars make sexual and violent threats against minors | Medium | LLM05 | ASI08 |  |
+| 6,201 | 2021 | [`INC-06178`](docs/incidents/2021.md#inc-06178) | VRChat users’ avatars make sexual and violent threats against minors | High | LLM05 | ASI08 |  |
 | 6,202 | 2021 | [`INC-06190`](docs/incidents/2021.md#inc-06190) | Worthless' Mater Dei Hospital medicine robots cause mass resignations | Medium | LLM06 | ASI09 |  |
 | 6,203 | 2021 | [`INC-06192`](docs/incidents/2021.md#inc-06192) | XPeng P7 on auto navigation crashes into truck, injuring driver | Medium | LLM05 | ASI08 |  |
 | 6,204 | 2021 | [`INC-06195`](docs/incidents/2021.md#inc-06195) | YouTube ads hate speech blocklist is 'inconsistent' and barely applied | Medium | LLM05, LLM07 | ASI08 |  |
@@ -7377,7 +7377,7 @@ All **7,720** incidents in a single table, newest-first. Each `INC-*****` link o
 | 7,247 | 2019 | [`INC-07222`](docs/incidents/2019.md#inc-07222) | Project Nightingale patient data sharing slammed for violating privacy | Medium | LLM02, LLM03 | ASI02, ASI03 |  |
 | 7,248 | 2019 | [`INC-07223`](docs/incidents/2019.md#inc-07223) | ProofPoint email-protection ML model evasion via copy-cat training | High |  |  |  |
 | 7,249 | 2019 | [`INC-07225`](docs/incidents/2019.md#inc-07225) | Researchers dispute OpenAI's claim that robot solved Rubik's cube | Medium | LLM06, LLM07 | ASI09 |  |
-| 7,250 | 2019 | [`INC-07226`](docs/incidents/2019.md#inc-07226) | SenseNets facial recognition data breach reveals Beijing Uyghur surveillance | Medium | LLM02, LLM03, LLM07 | ASI02, ASI03 |  |
+| 7,250 | 2019 | [`INC-07226`](docs/incidents/2019.md#inc-07226) | SenseNets facial recognition data breach reveals Beijing Uyghur surveillance | High | LLM02, LLM03, LLM07 | ASI02, ASI03 |  |
 | 7,251 | 2019 | [`INC-07228`](docs/incidents/2019.md#inc-07228) | Snapchat algorithm recommends teen connects with sex offenders | Medium | LLM05, LLM06 | ASI08, ASI09 |  |
 | 7,252 | 2019 | [`INC-07230`](docs/incidents/2019.md#inc-07230) | Starship robots impede wheelchair users | Medium | LLM05 | ASI08 |  |
 | 7,253 | 2019 | [`INC-07231`](docs/incidents/2019.md#inc-07231) | Student uses GPT-2 to dupe Medicaid | Medium | LLM06 | ASI09 |  |
@@ -7566,7 +7566,7 @@ All **7,720** incidents in a single table, newest-first. Each `INC-*****` link o
 | 7,436 | 2017 | [`INC-07394`](docs/incidents/2017.md#inc-07394) | Facebook accused of helping advertisers exclude older workers | Medium | LLM06, LLM07 | ASI09 |  |
 | 7,437 | 2017 | [`INC-07395`](docs/incidents/2017.md#inc-07395) | Facebook auto-translation incorrectly translates 'Good morning' to 'hurt them' | High | LLM09 |  |  |
 | 7,438 | 2017 | [`INC-07396`](docs/incidents/2017.md#inc-07396) | Facebook negotiation chatbots create secret language | Medium | LLM05, LLM07 | ASI08 |  |
-| 7,439 | 2017 | [`INC-07400`](docs/incidents/2017.md#inc-07400) | Gangs Matrix data leak puts young Londoners in "serious danger" | Medium | LLM02 | ASI03 |  |
+| 7,439 | 2017 | [`INC-07400`](docs/incidents/2017.md#inc-07400) | Gangs Matrix data leak puts young Londoners in "serious danger" | High | LLM02 | ASI03 |  |
 | 7,440 | 2017 | [`INC-07401`](docs/incidents/2017.md#inc-07401) | Gaydar AI that predicts sexual orientation accused of poor ethics | Medium |  |  |  |
 | 7,441 | 2017 | [`INC-07403`](docs/incidents/2017.md#inc-07403) | GM Chevrolet Bolt hits motorbike, injures rider | Medium | LLM05, LLM06, LLM07 | ASI08, ASI09 |  |
 | 7,442 | 2017 | [`INC-07404`](docs/incidents/2017.md#inc-07404) | Google Allo Smart Reply gives offensive responses | Medium | LLM02, LLM03 | ASI02, ASI03 |  |

--- a/data/curation_overrides.json
+++ b/data/curation_overrides.json
@@ -17,6 +17,11 @@
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
     },
+    "AIAAIC0196": {
+      "quality_tier": "reviewed",
+      "severity": "High",
+      "_note": "Mass-surveillance data breach (Uyghur targeting); raised Medium->High. Reviewed 2026-05."
+    },
     "AIAAIC0216": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
@@ -28,6 +33,11 @@
     "AIAAIC0270": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
+    },
+    "AIAAIC0285": {
+      "quality_tier": "reviewed",
+      "severity": "High",
+      "_note": "Police data leak placing named individuals in 'serious danger'; raised Medium->High. Reviewed 2026-05."
     },
     "AIAAIC0290": {
       "quality_tier": "reviewed",
@@ -44,6 +54,10 @@
     "AIAAIC039": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
+    },
+    "AIAAIC0471": {
+      "quality_tier": "reviewed",
+      "_note": "Proctoring data breach; Medium appropriate. Reviewed 2026-05."
     },
     "AIAAIC0490": {
       "quality_tier": "reviewed",
@@ -69,13 +83,27 @@
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
     },
+    "AIAAIC0616": {
+      "quality_tier": "reviewed",
+      "severity": "High",
+      "_note": "Content filter generated CSAM — serious; raised Medium->High. Reviewed 2026-05."
+    },
     "AIAAIC069": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
     },
+    "AIAAIC0696": {
+      "quality_tier": "reviewed",
+      "attack_vector": "privacy-violation",
+      "_note": "CSAM-*scanning* privacy controversy, not generation; corrected attack_vector. Reviewed 2026-05."
+    },
     "AIAAIC070": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
+    },
+    "AIAAIC0741": {
+      "quality_tier": "reviewed",
+      "_note": "Data leak exposing disinformation operation; Medium appropriate. Reviewed 2026-05."
     },
     "AIAAIC0811": {
       "quality_tier": "reviewed",
@@ -169,9 +197,19 @@
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
     },
+    "AIAAIC1095": {
+      "quality_tier": "reviewed",
+      "attack_vector": "other",
+      "_note": "CSAM *detection* false-positive, not generation; corrected attack_vector. Reviewed 2026-05."
+    },
     "AIAAIC1098": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
+    },
+    "AIAAIC1105": {
+      "quality_tier": "reviewed",
+      "severity": "High",
+      "_note": "Generation of synthetic CSAM — serious; raised Medium->High. Reviewed 2026-05."
     },
     "AIAAIC1110": {
       "quality_tier": "reviewed",
@@ -184,6 +222,10 @@
     "AIAAIC1112": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
+    },
+    "AIAAIC1211": {
+      "quality_tier": "reviewed",
+      "_note": "Phishing/malware generation capability study; Medium appropriate. Reviewed 2026-05."
     },
     "AIAAIC1323": {
       "quality_tier": "reviewed",
@@ -200,6 +242,10 @@
     "AIAAIC1360": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
+    },
+    "AIAAIC1412": {
+      "quality_tier": "reviewed",
+      "_note": "AI surfacing malware/fraud sites; Medium appropriate. Reviewed 2026-05."
     },
     "AIAAIC1441": {
       "quality_tier": "reviewed",
@@ -221,6 +267,19 @@
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
     },
+    "AIAAIC1600": {
+      "quality_tier": "reviewed",
+      "severity": "High",
+      "_note": "Sexual/violent threats targeting minors; raised Medium->High. Reviewed 2026-05."
+    },
+    "AIAAIC1614": {
+      "quality_tier": "reviewed",
+      "_note": "Malicious-content generation capability study; Medium appropriate. Reviewed 2026-05."
+    },
+    "AIAAIC1676": {
+      "quality_tier": "reviewed",
+      "_note": "Demonstrated phishing-abuse capability; Medium appropriate. Reviewed 2026-05."
+    },
     "AIAAIC1751": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
@@ -240,6 +299,15 @@
     "AIAAIC1885": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
+    },
+    "AIAAIC1896": {
+      "quality_tier": "reviewed",
+      "_note": "Jailbreak-robustness study; Medium appropriate. Reviewed 2026-05."
+    },
+    "AIAAIC1927": {
+      "quality_tier": "reviewed",
+      "severity": "High",
+      "_note": "AI-malware fraud causing severe personal/financial harm; raised Medium->High. Reviewed 2026-05."
     },
     "AIAAIC1944": {
       "quality_tier": "reviewed",
@@ -325,9 +393,18 @@
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
     },
+    "AIAAIC2159": {
+      "quality_tier": "reviewed",
+      "severity": "High",
+      "_note": "Training dataset found to contain CSAM — serious; raised Medium->High. Reviewed 2026-05."
+    },
     "AIAAIC2184": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."
+    },
+    "AIAAIC2207": {
+      "quality_tier": "reviewed",
+      "_note": "Infostealer exfiltrating assistant data; Medium appropriate. Reviewed 2026-05."
     },
     "AIAAIC2212": {
       "quality_tier": "reviewed",

--- a/data/incidents.json
+++ b/data/incidents.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generated": "2026-05-29",
+  "generated": "2026-05-30",
   "description": "Single source of truth for GenAI and agentic AI security incidents. Each entry is mapped to OWASP LLM Top 10 (2025), OWASP Agentic ASI Top 10, NIST AI RMF (AI 100-1), and MITRE ATLAS where applicable.",
   "schema": "schema/incident.schema.json",
   "incident_count": 7720,
@@ -22801,7 +22801,7 @@
       ],
       "added": "2026-05-16",
       "updated": "2026-05-26",
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -24959,7 +24959,7 @@
       "description": "AIAAIC report: Nude detection dataset contains child sexual abuse imagery. System: NudeNet. Technology: Database/dataset. Purpose: Detect nude images. Ethical issues: Accountability; Privacy/surveillance; Safety; Transparency. Response: Content/data removal.",
       "attack_vector": "csam-generation",
       "affected": "Bedapudi Praneeth",
-      "severity": "Medium",
+      "severity": "High",
       "owasp_llm": [
         "LLM05",
         "LLM06",
@@ -24995,8 +24995,8 @@
         "juris-multiple"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-29",
-      "quality_tier": "auto",
+      "updated": "2026-05-30",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -35031,7 +35031,7 @@
       "description": "AIAAIC report: AI malware scam \"destroys\" Disney employee's life. Technology: Machine learning. Purpose: Defraud. Ethical issues: Privacy/surveillance; Security. Response: Confidentiality loss.",
       "attack_vector": "malware",
       "affected": "Nullbulge",
-      "severity": "Medium",
+      "severity": "High",
       "owasp_llm": [
         "LLM02",
         "LLM03"
@@ -35066,8 +35066,8 @@
         "juris-usa"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-26",
-      "quality_tier": "auto",
+      "updated": "2026-05-30",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -36231,7 +36231,7 @@
       ],
       "added": "2026-05-16",
       "updated": "2026-05-16",
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -43376,7 +43376,7 @@
       ],
       "added": "2026-05-16",
       "updated": "2026-05-26",
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -45112,7 +45112,7 @@
       ],
       "added": "2026-05-16",
       "updated": "2026-05-16",
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -45418,7 +45418,7 @@
       "description": "AIAAIC report: VRChat users’ avatars make sexual and violent threats against minors. System: VRChat Safety and Trust System. Technology: Machine learning; Safety management system. Purpose: Manage system safety. Ethical issues: Safety.",
       "attack_vector": "csam-generation",
       "affected": "VRChat",
-      "severity": "Medium",
+      "severity": "High",
       "owasp_llm": [
         "LLM05"
       ],
@@ -45447,8 +45447,8 @@
         "juris-multiple;-usa"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-29",
-      "quality_tier": "auto",
+      "updated": "2026-05-30",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -50457,7 +50457,7 @@
       ],
       "added": "2026-05-16",
       "updated": "2026-05-26",
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -56181,7 +56181,7 @@
       ],
       "added": "2026-05-16",
       "updated": "2026-05-26",
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -59728,7 +59728,7 @@
       "description": "AIAAIC report: CivitAI accused of generating synthetic 'child pornography' images. System: CivitAI. Technology: Generative AI; Text-to-imag. Purpose: Generate images. Ethical issues: Privacy/surveillance; Safety; Transparency.",
       "attack_vector": "csam-generation",
       "affected": "CivitAI",
-      "severity": "Medium",
+      "severity": "High",
       "owasp_llm": [
         "LLM05",
         "LLM07"
@@ -59759,8 +59759,8 @@
         "juris-usa"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-29",
-      "quality_tier": "auto",
+      "updated": "2026-05-30",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -60047,7 +60047,7 @@
       "year": 2021,
       "category": "real-world",
       "description": "AIAAIC report: Google flags medical images of groins as CSAM. System: PhotoDNA. Technology: Hash matching; Machine learning. Purpose: Detect child sexual abuse material. Ethical issues: Accountability; Accuracy/reliability; Autonomy/agency; Transparency.",
-      "attack_vector": "csam-generation",
+      "attack_vector": "other",
       "affected": "Google",
       "severity": "Medium",
       "owasp_llm": [
@@ -60080,8 +60080,8 @@
         "juris-usa"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-29",
-      "quality_tier": "auto",
+      "updated": "2026-05-30",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -68876,7 +68876,7 @@
       ],
       "added": "2026-05-16",
       "updated": "2026-05-16",
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -69905,7 +69905,7 @@
       "year": 2021,
       "category": "real-world",
       "description": "AIAAIC report: Apple NeuralHash child sexual abuse scanning raises privacy concerns. System: NeuralHash. Technology: Perceptual hashing; Computer vision. Purpose: Detect child sexual abuse material. Ethical issues: Accuracy/reliability; Privacy/surveillance; Security. Reported consequences: Litigation.",
-      "attack_vector": "csam-generation",
+      "attack_vector": "privacy-violation",
       "affected": "Apple",
       "severity": "Medium",
       "owasp_llm": [
@@ -69942,8 +69942,8 @@
         "juris-usa"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-29",
-      "quality_tier": "auto",
+      "updated": "2026-05-30",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -72074,7 +72074,7 @@
       "description": "AIAAIC report: AI Dungeon offensive speech filter upgrade generates child porn. Technology: NLP/text analysis. Purpose: Minimise sexual content. Ethical issues: Accuracy/reliability; Consent; Safety; Privacy/surveillance. Response: System review/update.",
       "attack_vector": "csam-generation",
       "affected": "Latitude; OpenAI",
-      "severity": "Medium",
+      "severity": "High",
       "owasp_llm": [
         "LLM05"
       ],
@@ -72103,8 +72103,8 @@
         "juris-usa"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-29",
-      "quality_tier": "auto",
+      "updated": "2026-05-30",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -75707,7 +75707,7 @@
       ],
       "added": "2026-05-16",
       "updated": "2026-05-16",
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -78403,7 +78403,7 @@
       "description": "AIAAIC report: Gangs Matrix data leak puts young Londoners in \"serious danger\". System: Gangs Violence Matrix. Technology: Ranking algorithm. Purpose: Predict gang violence risk. Ethical issues: Fairness.",
       "attack_vector": "data-exfiltration",
       "affected": "Metropolitan Police Service (MPS)",
-      "severity": "Medium",
+      "severity": "High",
       "owasp_llm": [
         "LLM02"
       ],
@@ -78432,8 +78432,8 @@
         "juris-uk"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-16",
-      "quality_tier": "auto",
+      "updated": "2026-05-30",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -79611,7 +79611,7 @@
       "description": "AIAAIC report: SenseNets facial recognition data breach reveals Beijing Uyghur surveillance. Technology: Facial recognition. Purpose: Identify Uyghurs. Ethical issues: Dual use; Privacy/surveillance; Security; Transparency.",
       "attack_vector": "data-exfiltration",
       "affected": "Netposa Technologies/SenseNets",
-      "severity": "Medium",
+      "severity": "High",
       "owasp_llm": [
         "LLM02",
         "LLM03",
@@ -79649,8 +79649,8 @@
         "juris-china"
       ],
       "added": "2026-05-16",
-      "updated": "2026-05-16",
-      "quality_tier": "auto",
+      "updated": "2026-05-30",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {

--- a/data/incidents.min.json
+++ b/data/incidents.min.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generated": "2026-05-29",
+  "generated": "2026-05-30",
   "incident_count": 7720,
   "incidents": [
     {
@@ -14280,7 +14280,7 @@
         "aiaaic-sheet",
         "sector-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -15936,7 +15936,7 @@
       "title": "Nude detection dataset contains child sexual abuse imagery",
       "date": "2025",
       "year": 2025,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05",
@@ -15969,7 +15969,7 @@
         "sector-multiple",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -23685,7 +23685,7 @@
       "title": "AI malware scam \"destroys\" Disney employee's life",
       "date": "2024",
       "year": 2024,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "malware",
       "owasp_llm": [
         "LLM02",
@@ -23717,7 +23717,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -24606,7 +24606,7 @@
         "sector-multiple",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -29980,7 +29980,7 @@
         "sector-technology",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -31298,7 +31298,7 @@
         "sector-technology",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -31520,7 +31520,7 @@
       "title": "VRChat users’ avatars make sexual and violent threats against minors",
       "date": "2021",
       "year": 2021,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05"
@@ -31546,7 +31546,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-multiple;-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -35301,7 +35301,7 @@
         "sector-technology",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -39566,7 +39566,7 @@
         "sector-technology",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -42237,7 +42237,7 @@
       "title": "CivitAI accused of generating synthetic 'child pornography' images",
       "date": "2023",
       "year": 2023,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05",
@@ -42265,7 +42265,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -42482,7 +42482,7 @@
       "date": "2021",
       "year": 2021,
       "severity": "Medium",
-      "attack_vector": "csam-generation",
+      "attack_vector": "other",
       "owasp_llm": [
         "LLM06",
         "LLM07"
@@ -42509,7 +42509,7 @@
         "sector-health",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -49169,7 +49169,7 @@
         "sector-politics",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -49963,7 +49963,7 @@
       "date": "2021",
       "year": 2021,
       "severity": "Medium",
-      "attack_vector": "csam-generation",
+      "attack_vector": "privacy-violation",
       "owasp_llm": [
         "LLM02",
         "LLM03"
@@ -49994,7 +49994,7 @@
         "sector-technology",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -51623,7 +51623,7 @@
       "title": "AI Dungeon offensive speech filter upgrade generates child porn",
       "date": "2021",
       "year": 2021,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05"
@@ -51649,7 +51649,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -54383,7 +54383,7 @@
         "sector-education",
         "juris-canada;-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -56412,7 +56412,7 @@
       "title": "Gangs Matrix data leak puts young Londoners in \"serious danger\"",
       "date": "2017",
       "year": 2017,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "data-exfiltration",
       "owasp_llm": [
         "LLM02"
@@ -56438,7 +56438,7 @@
         "sector-govt---police",
         "juris-uk"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -57323,7 +57323,7 @@
       "title": "SenseNets facial recognition data breach reveals Beijing Uyghur surveillance",
       "date": "2019",
       "year": 2019,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "data-exfiltration",
       "owasp_llm": [
         "LLM02",
@@ -57358,7 +57358,7 @@
         "sector-govt---police;-govt---security;-politics",
         "juris-china"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {

--- a/docs/charts/severity_stack.svg
+++ b/docs/charts/severity_stack.svg
@@ -10,8 +10,8 @@
 <rect x="97.7" y="197.2" width="39.1" height="3.5" fill="#8a6d00"><title>2016 Medium: 43</title></rect>
 <text x="117.3" y="218" text-anchor="middle" fill="#666">2016</text>
 <rect x="146.6" y="202.9" width="39.1" height="1.1" fill="#b40000"><title>2017 Critical: 14</title></rect>
-<rect x="146.6" y="200.4" width="39.1" height="2.5" fill="#cc4400"><title>2017 High: 30</title></rect>
-<rect x="146.6" y="195.3" width="39.1" height="5.1" fill="#8a6d00"><title>2017 Medium: 62</title></rect>
+<rect x="146.6" y="200.3" width="39.1" height="2.5" fill="#cc4400"><title>2017 High: 31</title></rect>
+<rect x="146.6" y="195.3" width="39.1" height="5.0" fill="#8a6d00"><title>2017 Medium: 61</title></rect>
 <rect x="146.6" y="195.2" width="39.1" height="0.1" fill="#2a7f2a"><title>2017 Low: 1</title></rect>
 <text x="166.1" y="218" text-anchor="middle" fill="#666">2017</text>
 <rect x="195.4" y="202.4" width="39.1" height="1.6" fill="#b40000"><title>2018 Critical: 20</title></rect>
@@ -19,8 +19,8 @@
 <rect x="195.4" y="196.1" width="39.1" height="4.4" fill="#8a6d00"><title>2018 Medium: 54</title></rect>
 <text x="214.9" y="218" text-anchor="middle" fill="#666">2018</text>
 <rect x="244.2" y="202.0" width="39.1" height="2.0" fill="#b40000"><title>2019 Critical: 24</title></rect>
-<rect x="244.2" y="200.0" width="39.1" height="2.0" fill="#cc4400"><title>2019 High: 25</title></rect>
-<rect x="244.2" y="194.7" width="39.1" height="5.2" fill="#8a6d00"><title>2019 Medium: 64</title></rect>
+<rect x="244.2" y="199.9" width="39.1" height="2.1" fill="#cc4400"><title>2019 High: 26</title></rect>
+<rect x="244.2" y="194.7" width="39.1" height="5.2" fill="#8a6d00"><title>2019 Medium: 63</title></rect>
 <rect x="244.2" y="194.7" width="39.1" height="0.1" fill="#2a7f2a"><title>2019 Low: 1</title></rect>
 <text x="263.8" y="218" text-anchor="middle" fill="#666">2019</text>
 <rect x="293.1" y="188.0" width="39.1" height="16.0" fill="#b40000"><title>2020 Critical: 195</title></rect>
@@ -29,8 +29,8 @@
 <rect x="293.1" y="126.3" width="39.1" height="0.1" fill="#2a7f2a"><title>2020 Low: 1</title></rect>
 <text x="312.6" y="218" text-anchor="middle" fill="#666">2020</text>
 <rect x="341.9" y="192.7" width="39.1" height="11.3" fill="#b40000"><title>2021 Critical: 138</title></rect>
-<rect x="341.9" y="170.9" width="39.1" height="21.8" fill="#cc4400"><title>2021 High: 266</title></rect>
-<rect x="341.9" y="143.2" width="39.1" height="27.7" fill="#8a6d00"><title>2021 Medium: 338</title></rect>
+<rect x="341.9" y="170.7" width="39.1" height="22.0" fill="#cc4400"><title>2021 High: 268</title></rect>
+<rect x="341.9" y="143.2" width="39.1" height="27.5" fill="#8a6d00"><title>2021 Medium: 336</title></rect>
 <rect x="341.9" y="135.8" width="39.1" height="7.5" fill="#2a7f2a"><title>2021 Low: 91</title></rect>
 <text x="361.4" y="218" text-anchor="middle" fill="#666">2021</text>
 <rect x="390.7" y="200.1" width="39.1" height="3.9" fill="#b40000"><title>2022 Critical: 47</title></rect>
@@ -38,18 +38,18 @@
 <rect x="390.7" y="174.5" width="39.1" height="18.7" fill="#8a6d00"><title>2022 Medium: 228</title></rect>
 <text x="410.3" y="218" text-anchor="middle" fill="#666">2022</text>
 <rect x="439.6" y="197.5" width="39.1" height="6.5" fill="#b40000"><title>2023 Critical: 79</title></rect>
-<rect x="439.6" y="182.7" width="39.1" height="14.8" fill="#cc4400"><title>2023 High: 181</title></rect>
-<rect x="439.6" y="152.6" width="39.1" height="30.1" fill="#8a6d00"><title>2023 Medium: 367</title></rect>
+<rect x="439.6" y="182.6" width="39.1" height="14.9" fill="#cc4400"><title>2023 High: 182</title></rect>
+<rect x="439.6" y="152.6" width="39.1" height="30.0" fill="#8a6d00"><title>2023 Medium: 366</title></rect>
 <rect x="439.6" y="152.0" width="39.1" height="0.7" fill="#2a7f2a"><title>2023 Low: 8</title></rect>
 <text x="459.1" y="218" text-anchor="middle" fill="#666">2023</text>
 <rect x="488.4" y="189.3" width="39.1" height="14.7" fill="#b40000"><title>2024 Critical: 179</title></rect>
-<rect x="488.4" y="160.8" width="39.1" height="28.5" fill="#cc4400"><title>2024 High: 348</title></rect>
-<rect x="488.4" y="124.6" width="39.1" height="36.2" fill="#8a6d00"><title>2024 Medium: 442</title></rect>
+<rect x="488.4" y="160.7" width="39.1" height="28.6" fill="#cc4400"><title>2024 High: 349</title></rect>
+<rect x="488.4" y="124.6" width="39.1" height="36.1" fill="#8a6d00"><title>2024 Medium: 441</title></rect>
 <rect x="488.4" y="123.9" width="39.1" height="0.7" fill="#2a7f2a"><title>2024 Low: 9</title></rect>
 <text x="507.9" y="218" text-anchor="middle" fill="#666">2024</text>
 <rect x="537.2" y="182.3" width="39.1" height="21.7" fill="#b40000"><title>2025 Critical: 265</title></rect>
-<rect x="537.2" y="141.4" width="39.1" height="40.9" fill="#cc4400"><title>2025 High: 499</title></rect>
-<rect x="537.2" y="100.3" width="39.1" height="41.1" fill="#8a6d00"><title>2025 Medium: 502</title></rect>
+<rect x="537.2" y="141.3" width="39.1" height="41.0" fill="#cc4400"><title>2025 High: 500</title></rect>
+<rect x="537.2" y="100.3" width="39.1" height="41.0" fill="#8a6d00"><title>2025 Medium: 501</title></rect>
 <rect x="537.2" y="99.6" width="39.1" height="0.7" fill="#2a7f2a"><title>2025 Low: 8</title></rect>
 <text x="556.8" y="218" text-anchor="middle" fill="#666">2025</text>
 <rect x="586.1" y="164.8" width="39.1" height="39.2" fill="#b40000"><title>2026 Critical: 478</title></rect>

--- a/docs/data/incidents.min.json
+++ b/docs/data/incidents.min.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generated": "2026-05-29",
+  "generated": "2026-05-30",
   "incident_count": 7720,
   "incidents": [
     {
@@ -14280,7 +14280,7 @@
         "aiaaic-sheet",
         "sector-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -15936,7 +15936,7 @@
       "title": "Nude detection dataset contains child sexual abuse imagery",
       "date": "2025",
       "year": 2025,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05",
@@ -15969,7 +15969,7 @@
         "sector-multiple",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -23685,7 +23685,7 @@
       "title": "AI malware scam \"destroys\" Disney employee's life",
       "date": "2024",
       "year": 2024,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "malware",
       "owasp_llm": [
         "LLM02",
@@ -23717,7 +23717,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -24606,7 +24606,7 @@
         "sector-multiple",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -29980,7 +29980,7 @@
         "sector-technology",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -31298,7 +31298,7 @@
         "sector-technology",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -31520,7 +31520,7 @@
       "title": "VRChat users’ avatars make sexual and violent threats against minors",
       "date": "2021",
       "year": 2021,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05"
@@ -31546,7 +31546,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-multiple;-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -35301,7 +35301,7 @@
         "sector-technology",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -39566,7 +39566,7 @@
         "sector-technology",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -42237,7 +42237,7 @@
       "title": "CivitAI accused of generating synthetic 'child pornography' images",
       "date": "2023",
       "year": 2023,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05",
@@ -42265,7 +42265,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -42482,7 +42482,7 @@
       "date": "2021",
       "year": 2021,
       "severity": "Medium",
-      "attack_vector": "csam-generation",
+      "attack_vector": "other",
       "owasp_llm": [
         "LLM06",
         "LLM07"
@@ -42509,7 +42509,7 @@
         "sector-health",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -49169,7 +49169,7 @@
         "sector-politics",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -49963,7 +49963,7 @@
       "date": "2021",
       "year": 2021,
       "severity": "Medium",
-      "attack_vector": "csam-generation",
+      "attack_vector": "privacy-violation",
       "owasp_llm": [
         "LLM02",
         "LLM03"
@@ -49994,7 +49994,7 @@
         "sector-technology",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -51623,7 +51623,7 @@
       "title": "AI Dungeon offensive speech filter upgrade generates child porn",
       "date": "2021",
       "year": 2021,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05"
@@ -51649,7 +51649,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -54383,7 +54383,7 @@
         "sector-education",
         "juris-canada;-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -56412,7 +56412,7 @@
       "title": "Gangs Matrix data leak puts young Londoners in \"serious danger\"",
       "date": "2017",
       "year": 2017,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "data-exfiltration",
       "owasp_llm": [
         "LLM02"
@@ -56438,7 +56438,7 @@
         "sector-govt---police",
         "juris-uk"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -57323,7 +57323,7 @@
       "title": "SenseNets facial recognition data breach reveals Beijing Uyghur surveillance",
       "date": "2019",
       "year": 2019,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "data-exfiltration",
       "owasp_llm": [
         "LLM02",
@@ -57358,7 +57358,7 @@
         "sector-govt---police;-govt---security;-politics",
         "juris-china"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {

--- a/docs/incident/INC-02967.md
+++ b/docs/incident/INC-02967.md
@@ -4,7 +4,7 @@ layout: incident
 permalink: /incident/INC-02967.html
 incident_id: INC-02967
 year: 2025
-severity: Medium
+severity: High
 description_preview: "AIAAIC report: Nude detection dataset contains child sexual abuse imagery. System: NudeNet. Technology: Database/dataset. Purpose: Detect nude images. Ethical issues: Accountability; Privacy/surveilla"
 tags_str: "aiaaic, aiaaic-sheet, sector-multiple, juris-multiple"
 ---
@@ -14,7 +14,7 @@ tags_str: "aiaaic, aiaaic-sheet, sector-multiple, juris-multiple"
 ### INC-02967  [↗](/incident/INC-02967.html)
 
 **Nude detection dataset contains child sexual abuse imagery**  
-_2025 · real-world · Severity: Medium_
+_2025 · real-world · Severity: High_
 
 AIAAIC report: Nude detection dataset contains child sexual abuse imagery. System: NudeNet. Technology: Database/dataset. Purpose: Detect nude images. Ethical issues: Accountability; Privacy/surveillance; Safety; Transparency. Response: Content/data removal.
 

--- a/docs/incident/INC-03466.md
+++ b/docs/incident/INC-03466.md
@@ -4,7 +4,7 @@ layout: incident
 permalink: /incident/INC-03466.html
 incident_id: INC-03466
 year: 2024
-severity: Medium
+severity: High
 description_preview: "AIAAIC report: AI malware scam \"destroys\" Disney employee's life. Technology: Machine learning. Purpose: Defraud. Ethical issues: Privacy/surveillance; Security. Response: Confidentiality loss."
 tags_str: "aiaaic, aiaaic-sheet, sector-media/entertainment/sports/arts, juris-usa"
 ---
@@ -14,7 +14,7 @@ tags_str: "aiaaic, aiaaic-sheet, sector-media/entertainment/sports/arts, juris-u
 ### INC-03466  [↗](/incident/INC-03466.html)
 
 **AI malware scam "destroys" Disney employee's life**  
-_2024 · real-world · Severity: Medium_
+_2024 · real-world · Severity: High_
 
 AIAAIC report: AI malware scam "destroys" Disney employee's life. Technology: Machine learning. Purpose: Defraud. Ethical issues: Privacy/surveillance; Security. Response: Confidentiality loss.
 

--- a/docs/incident/INC-04571.md
+++ b/docs/incident/INC-04571.md
@@ -4,7 +4,7 @@ layout: incident
 permalink: /incident/INC-04571.html
 incident_id: INC-04571
 year: 2023
-severity: Medium
+severity: High
 description_preview: "AIAAIC report: CivitAI accused of generating synthetic 'child pornography' images. System: CivitAI. Technology: Generative AI; Text-to-imag. Purpose: Generate images. Ethical issues: Privacy/surveilla"
 tags_str: "aiaaic, aiaaic-sheet, sector-media/entertainment/sports/arts, juris-usa"
 ---
@@ -14,7 +14,7 @@ tags_str: "aiaaic, aiaaic-sheet, sector-media/entertainment/sports/arts, juris-u
 ### INC-04571  [↗](/incident/INC-04571.html)
 
 **CivitAI accused of generating synthetic 'child pornography' images**  
-_2023 · real-world · Severity: Medium_
+_2023 · real-world · Severity: High_
 
 AIAAIC report: CivitAI accused of generating synthetic 'child pornography' images. System: CivitAI. Technology: Generative AI; Text-to-imag. Purpose: Generate images. Ethical issues: Privacy/surveillance; Safety; Transparency.
 

--- a/docs/incident/INC-05382.md
+++ b/docs/incident/INC-05382.md
@@ -4,7 +4,7 @@ layout: incident
 permalink: /incident/INC-05382.html
 incident_id: INC-05382
 year: 2021
-severity: Medium
+severity: High
 description_preview: "AIAAIC report: AI Dungeon offensive speech filter upgrade generates child porn. Technology: NLP/text analysis. Purpose: Minimise sexual content. Ethical issues: Accuracy/reliability; Consent; Safety;"
 tags_str: "aiaaic, aiaaic-sheet, sector-media/entertainment/sports/arts, juris-usa"
 ---
@@ -14,7 +14,7 @@ tags_str: "aiaaic, aiaaic-sheet, sector-media/entertainment/sports/arts, juris-u
 ### INC-05382  [↗](/incident/INC-05382.html)
 
 **AI Dungeon offensive speech filter upgrade generates child porn**  
-_2021 · real-world · Severity: Medium_
+_2021 · real-world · Severity: High_
 
 AIAAIC report: AI Dungeon offensive speech filter upgrade generates child porn. Technology: NLP/text analysis. Purpose: Minimise sexual content. Ethical issues: Accuracy/reliability; Consent; Safety; Privacy/surveillance. Response: System review/update.
 

--- a/docs/incident/INC-05486.md
+++ b/docs/incident/INC-05486.md
@@ -19,7 +19,7 @@ _2021 · real-world · Severity: Medium_
 AIAAIC report: Apple NeuralHash child sexual abuse scanning raises privacy concerns. System: NeuralHash. Technology: Perceptual hashing; Computer vision. Purpose: Detect child sexual abuse material. Ethical issues: Accuracy/reliability; Privacy/surveillance; Security. Reported consequences: Litigation.
 
 **Affected:** Apple  
-**Attack vector:** `csam-generation`  
+**Attack vector:** `privacy-violation`  
 
 **OWASP LLM Top 10:** `LLM02`, `LLM03`  
 **OWASP Agentic (ASI):** `ASI02`, `ASI03`  

--- a/docs/incident/INC-05669.md
+++ b/docs/incident/INC-05669.md
@@ -19,7 +19,7 @@ _2021 · real-world · Severity: Medium_
 AIAAIC report: Google flags medical images of groins as CSAM. System: PhotoDNA. Technology: Hash matching; Machine learning. Purpose: Detect child sexual abuse material. Ethical issues: Accountability; Accuracy/reliability; Autonomy/agency; Transparency.
 
 **Affected:** Google  
-**Attack vector:** `csam-generation`  
+**Attack vector:** `other`  
 
 **OWASP LLM Top 10:** `LLM06`, `LLM07`  
 **OWASP Agentic (ASI):** `ASI09`  

--- a/docs/incident/INC-06178.md
+++ b/docs/incident/INC-06178.md
@@ -4,7 +4,7 @@ layout: incident
 permalink: /incident/INC-06178.html
 incident_id: INC-06178
 year: 2021
-severity: Medium
+severity: High
 description_preview: "AIAAIC report: VRChat users’ avatars make sexual and violent threats against minors. System: VRChat Safety and Trust System. Technology: Machine learning; Safety management system. Purpose: Manage sys"
 tags_str: "aiaaic, aiaaic-sheet, sector-media/entertainment/sports/arts, juris-multiple;-usa"
 ---
@@ -14,7 +14,7 @@ tags_str: "aiaaic, aiaaic-sheet, sector-media/entertainment/sports/arts, juris-m
 ### INC-06178  [↗](/incident/INC-06178.html)
 
 **VRChat users’ avatars make sexual and violent threats against minors**  
-_2021 · real-world · Severity: Medium_
+_2021 · real-world · Severity: High_
 
 AIAAIC report: VRChat users’ avatars make sexual and violent threats against minors. System: VRChat Safety and Trust System. Technology: Machine learning; Safety management system. Purpose: Manage system safety. Ethical issues: Safety.
 

--- a/docs/incident/INC-07226.md
+++ b/docs/incident/INC-07226.md
@@ -4,7 +4,7 @@ layout: incident
 permalink: /incident/INC-07226.html
 incident_id: INC-07226
 year: 2019
-severity: Medium
+severity: High
 description_preview: "AIAAIC report: SenseNets facial recognition data breach reveals Beijing Uyghur surveillance. Technology: Facial recognition. Purpose: Identify Uyghurs. Ethical issues: Dual use; Privacy/surveillance;"
 tags_str: "aiaaic, aiaaic-sheet, sector-govt---police;-govt---security;-politics, juris-china"
 ---
@@ -14,7 +14,7 @@ tags_str: "aiaaic, aiaaic-sheet, sector-govt---police;-govt---security;-politics
 ### INC-07226  [↗](/incident/INC-07226.html)
 
 **SenseNets facial recognition data breach reveals Beijing Uyghur surveillance**  
-_2019 · real-world · Severity: Medium_
+_2019 · real-world · Severity: High_
 
 AIAAIC report: SenseNets facial recognition data breach reveals Beijing Uyghur surveillance. Technology: Facial recognition. Purpose: Identify Uyghurs. Ethical issues: Dual use; Privacy/surveillance; Security; Transparency.
 

--- a/docs/incident/INC-07400.md
+++ b/docs/incident/INC-07400.md
@@ -4,7 +4,7 @@ layout: incident
 permalink: /incident/INC-07400.html
 incident_id: INC-07400
 year: 2017
-severity: Medium
+severity: High
 description_preview: "AIAAIC report: Gangs Matrix data leak puts young Londoners in \"serious danger\". System: Gangs Violence Matrix. Technology: Ranking algorithm. Purpose: Predict gang violence risk. Ethical issues: Fairn"
 tags_str: "aiaaic, aiaaic-sheet, sector-govt---police, juris-uk"
 ---
@@ -14,7 +14,7 @@ tags_str: "aiaaic, aiaaic-sheet, sector-govt---police, juris-uk"
 ### INC-07400  [↗](/incident/INC-07400.html)
 
 **Gangs Matrix data leak puts young Londoners in "serious danger"**  
-_2017 · real-world · Severity: Medium_
+_2017 · real-world · Severity: High_
 
 AIAAIC report: Gangs Matrix data leak puts young Londoners in "serious danger". System: Gangs Violence Matrix. Technology: Ranking algorithm. Purpose: Predict gang violence risk. Ethical issues: Fairness.
 

--- a/docs/incidents/2017.md
+++ b/docs/incidents/2017.md
@@ -1965,7 +1965,7 @@ AIAAIC report: Facebook negotiation chatbots create secret language. System: End
 ### INC-07400  [↗](/incident/INC-07400.html)
 
 **Gangs Matrix data leak puts young Londoners in "serious danger"**  
-_2017 · real-world · Severity: Medium_
+_2017 · real-world · Severity: High_
 
 AIAAIC report: Gangs Matrix data leak puts young Londoners in "serious danger". System: Gangs Violence Matrix. Technology: Ranking algorithm. Purpose: Predict gang violence risk. Ethical issues: Fairness.
 

--- a/docs/incidents/2019.md
+++ b/docs/incidents/2019.md
@@ -2464,7 +2464,7 @@ AIAAIC report: Researchers dispute OpenAI's claim that robot solved Rubik's cube
 ### INC-07226  [↗](/incident/INC-07226.html)
 
 **SenseNets facial recognition data breach reveals Beijing Uyghur surveillance**  
-_2019 · real-world · Severity: Medium_
+_2019 · real-world · Severity: High_
 
 AIAAIC report: SenseNets facial recognition data breach reveals Beijing Uyghur surveillance. Technology: Facial recognition. Purpose: Identify Uyghurs. Ethical issues: Dual use; Privacy/surveillance; Security; Transparency.
 

--- a/docs/incidents/2021.md
+++ b/docs/incidents/2021.md
@@ -18638,7 +18638,7 @@ AIAAIC report: Adobe Project Morpheus slammed for deepfake uses. System: Adobe M
 ### INC-05382  [↗](/incident/INC-05382.html)
 
 **AI Dungeon offensive speech filter upgrade generates child porn**  
-_2021 · real-world · Severity: Medium_
+_2021 · real-world · Severity: High_
 
 AIAAIC report: AI Dungeon offensive speech filter upgrade generates child porn. Technology: NLP/text analysis. Purpose: Minimise sexual content. Ethical issues: Accuracy/reliability; Consent; Safety; Privacy/surveillance. Response: System review/update.
 
@@ -19046,7 +19046,7 @@ _2021 · real-world · Severity: Medium_
 AIAAIC report: Apple NeuralHash child sexual abuse scanning raises privacy concerns. System: NeuralHash. Technology: Perceptual hashing; Computer vision. Purpose: Detect child sexual abuse material. Ethical issues: Accuracy/reliability; Privacy/surveillance; Security. Reported consequences: Litigation.
 
 **Affected:** Apple  
-**Attack vector:** `csam-generation`  
+**Attack vector:** `privacy-violation`  
 
 **OWASP LLM Top 10:** `LLM02`, `LLM03`  
 **OWASP Agentic (ASI):** `ASI02`, `ASI03`  
@@ -20012,7 +20012,7 @@ _2021 · real-world · Severity: Medium_
 AIAAIC report: Google flags medical images of groins as CSAM. System: PhotoDNA. Technology: Hash matching; Machine learning. Purpose: Detect child sexual abuse material. Ethical issues: Accountability; Accuracy/reliability; Autonomy/agency; Transparency.
 
 **Affected:** Google  
-**Attack vector:** `csam-generation`  
+**Attack vector:** `other`  
 
 **OWASP LLM Top 10:** `LLM06`, `LLM07`  
 **OWASP Agentic (ASI):** `ASI09`  
@@ -22198,7 +22198,7 @@ AIAAIC report: Verkada facial recognition camera hack prompts security, ethics c
 ### INC-06178  [↗](/incident/INC-06178.html)
 
 **VRChat users’ avatars make sexual and violent threats against minors**  
-_2021 · real-world · Severity: Medium_
+_2021 · real-world · Severity: High_
 
 AIAAIC report: VRChat users’ avatars make sexual and violent threats against minors. System: VRChat Safety and Trust System. Technology: Machine learning; Safety management system. Purpose: Manage system safety. Ethical issues: Safety.
 

--- a/docs/incidents/2023.md
+++ b/docs/incidents/2023.md
@@ -11182,7 +11182,7 @@ AIAAIC report: Cigna PxDx accused of accelerating health insurance claim denials
 ### INC-04571  [↗](/incident/INC-04571.html)
 
 **CivitAI accused of generating synthetic 'child pornography' images**  
-_2023 · real-world · Severity: Medium_
+_2023 · real-world · Severity: High_
 
 AIAAIC report: CivitAI accused of generating synthetic 'child pornography' images. System: CivitAI. Technology: Generative AI; Text-to-imag. Purpose: Generate images. Ethical issues: Privacy/surveillance; Safety; Transparency.
 

--- a/docs/incidents/2024.md
+++ b/docs/incidents/2024.md
@@ -17853,7 +17853,7 @@ AIAAIC report: AI hiring chatbot hack violates applicants' privacy. System: Chat
 ### INC-03466  [↗](/incident/INC-03466.html)
 
 **AI malware scam "destroys" Disney employee's life**  
-_2024 · real-world · Severity: Medium_
+_2024 · real-world · Severity: High_
 
 AIAAIC report: AI malware scam "destroys" Disney employee's life. Technology: Machine learning. Purpose: Defraud. Ethical issues: Privacy/surveillance; Security. Response: Confidentiality loss.
 

--- a/docs/incidents/2025.md
+++ b/docs/incidents/2025.md
@@ -31677,7 +31677,7 @@ AIAAIC report: North Korean hackers use ChatGPT to make deepfake military IDs. S
 ### INC-02967  [↗](/incident/INC-02967.html)
 
 **Nude detection dataset contains child sexual abuse imagery**  
-_2025 · real-world · Severity: Medium_
+_2025 · real-world · Severity: High_
 
 AIAAIC report: Nude detection dataset contains child sexual abuse imagery. System: NudeNet. Technology: Database/dataset. Purpose: Detect nude images. Ethical issues: Accountability; Privacy/surveillance; Safety; Transparency. Response: Content/data removal.
 

--- a/src/genai_incidents/data/incidents.min.json
+++ b/src/genai_incidents/data/incidents.min.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "generated": "2026-05-29",
+  "generated": "2026-05-30",
   "incident_count": 7720,
   "incidents": [
     {
@@ -14280,7 +14280,7 @@
         "aiaaic-sheet",
         "sector-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -15936,7 +15936,7 @@
       "title": "Nude detection dataset contains child sexual abuse imagery",
       "date": "2025",
       "year": 2025,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05",
@@ -15969,7 +15969,7 @@
         "sector-multiple",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -23685,7 +23685,7 @@
       "title": "AI malware scam \"destroys\" Disney employee's life",
       "date": "2024",
       "year": 2024,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "malware",
       "owasp_llm": [
         "LLM02",
@@ -23717,7 +23717,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -24606,7 +24606,7 @@
         "sector-multiple",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -29980,7 +29980,7 @@
         "sector-technology",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -31298,7 +31298,7 @@
         "sector-technology",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -31520,7 +31520,7 @@
       "title": "VRChat users’ avatars make sexual and violent threats against minors",
       "date": "2021",
       "year": 2021,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05"
@@ -31546,7 +31546,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-multiple;-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -35301,7 +35301,7 @@
         "sector-technology",
         "juris-multiple"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -39566,7 +39566,7 @@
         "sector-technology",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -42237,7 +42237,7 @@
       "title": "CivitAI accused of generating synthetic 'child pornography' images",
       "date": "2023",
       "year": 2023,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05",
@@ -42265,7 +42265,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -42482,7 +42482,7 @@
       "date": "2021",
       "year": 2021,
       "severity": "Medium",
-      "attack_vector": "csam-generation",
+      "attack_vector": "other",
       "owasp_llm": [
         "LLM06",
         "LLM07"
@@ -42509,7 +42509,7 @@
         "sector-health",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -49169,7 +49169,7 @@
         "sector-politics",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -49963,7 +49963,7 @@
       "date": "2021",
       "year": 2021,
       "severity": "Medium",
-      "attack_vector": "csam-generation",
+      "attack_vector": "privacy-violation",
       "owasp_llm": [
         "LLM02",
         "LLM03"
@@ -49994,7 +49994,7 @@
         "sector-technology",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -51623,7 +51623,7 @@
       "title": "AI Dungeon offensive speech filter upgrade generates child porn",
       "date": "2021",
       "year": 2021,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "csam-generation",
       "owasp_llm": [
         "LLM05"
@@ -51649,7 +51649,7 @@
         "sector-media/entertainment/sports/arts",
         "juris-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -54383,7 +54383,7 @@
         "sector-education",
         "juris-canada;-usa"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -56412,7 +56412,7 @@
       "title": "Gangs Matrix data leak puts young Londoners in \"serious danger\"",
       "date": "2017",
       "year": 2017,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "data-exfiltration",
       "owasp_llm": [
         "LLM02"
@@ -56438,7 +56438,7 @@
         "sector-govt---police",
         "juris-uk"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {
@@ -57323,7 +57323,7 @@
       "title": "SenseNets facial recognition data breach reveals Beijing Uyghur surveillance",
       "date": "2019",
       "year": 2019,
-      "severity": "Medium",
+      "severity": "High",
       "attack_vector": "data-exfiltration",
       "owasp_llm": [
         "LLM02",
@@ -57358,7 +57358,7 @@
         "sector-govt---police;-govt---security;-politics",
         "juris-china"
       ],
-      "quality_tier": "auto",
+      "quality_tier": "reviewed",
       "corpus": "security"
     },
     {


### PR DESCRIPTION
Continues the curation pass. I individually reviewed the **17 non-deepfake, security-attack-vector Medium AIAAIC entries** — and review caught real errors, not just tier gaps.

## Corrections (recorded in `data/curation_overrides.json`)

**7 severity bumps Medium → High** (described harm clearly exceeds the AIAAIC default):
- Synthetic **CSAM generation** — CivitAI, AI Dungeon filter
- Training **dataset containing CSAM** (NudeNet)
- AI-malware fraud that "**destroys**" a victim's life
- **Sexual/violent threats against minors** (VRChat)
- Police **data leak placing named individuals in "serious danger"** (Gangs Matrix)
- **Mass-surveillance data breach** (SenseNets / Uyghur targeting)

**2 attack_vector corrections** — `csam-generation` was wrongly applied to CSAM *detection* cases:
- Google flagging medical images as CSAM (false-positive) → `other`
- Apple NeuralHash CSAM-scanning privacy controversy → `privacy-violation`

**All 17 → `reviewed`.**

## Notes
- `auto`: 18.1% → 17.9% — the **value is the severity/classification fixes**, not the count. The remaining ~1,380 auto are single-source Medium AIAAIC + recent unscored CVEs (which auto-promote once NVD assigns CVSS), best curated incrementally via the override file.
- These are recorded as durable overrides (now 102 entries), surviving rebuilds.

## Verification
- ✅ `pytest` → 74 passed
- ✅ `validate.py` → 7,720/7,720 valid · idempotent · cross-day reproducible (verified clock forced forward → zero drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)