### PR TITLE
feat(reach): Hugging Face dataset + datasheet + data dictionary

### DIFF
--- a/.github/workflows/huggingface.yml
+++ b/.github/workflows/huggingface.yml
@@ -1,0 +1,38 @@
+name: Publish to Hugging Face
+
+# Publishes the dataset to the Hugging Face Hub on each GitHub release.
+# Requires repo secrets:
+#   HF_TOKEN  - a Hugging Face write token
+#   HF_REPO   - target dataset repo, e.g. "emmanuelgjr/genai-incidents" (optional;
+#               defaults to the exporter's built-in repo id)
+# No-ops cleanly if HF_TOKEN is absent, so forks without the secret don't fail.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install -r requirements.txt huggingface_hub
+      - name: Build and push dataset
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_REPO: ${{ secrets.HF_REPO }}
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "::warning::HF_TOKEN not set — building artifact only, skipping upload."
+            python scripts/export_huggingface.py
+          else
+            python scripts/export_huggingface.py --push ${HF_REPO:+--repo "$HF_REPO"}
+          fi

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build validate render merge install clean test stix ingest-cve ingest-airi ingest-aiaaic ingest-oecd-aim ingest-all
+.PHONY: build validate render merge install clean test stix huggingface ingest-cve ingest-airi ingest-aiaaic ingest-oecd-aim ingest-all
 
 install:
 	pip install -r requirements.txt
@@ -21,6 +21,10 @@ validate:
 # STIX 2.1 bundle for threat-intel platforms (build artifact, not committed).
 stix:
 	python scripts/export_stix.py
+
+# Hugging Face dataset package (dist/hf/); add --push with HF_TOKEN set to upload.
+huggingface:
+	python scripts/export_huggingface.py
 
 # Pull AI/ML/LLM/agent CVEs from NVD + GHSA + OSV.
 # Output: ingest/cve_nvd_expanded.json

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 
 - 🔎 **Searchable site:** <https://emmanuelgjr.github.io/genai_incidents/>
 - 📦 **Python:** `pip install genai-incidents`
+- 🤗 **Hugging Face:** `load_dataset("emmanuelgjr/genai-incidents")` — built with `make huggingface`
 - 🛰️ **STIX 2.1 bundle** (for OpenCTI / MISP / TAXII): <https://emmanuelgjr.github.io/genai_incidents/data/incidents.stix.json> — incidents as `x-genai-incident` SDOs linked to MITRE ATLAS `attack-pattern`s and CVE `vulnerability`s. Build locally with `make stix`.
+- 📖 **Field reference:** [`docs/DATA_DICTIONARY.md`](docs/DATA_DICTIONARY.md) · **Provenance & limitations:** [`docs/DATASHEET.md`](docs/DATASHEET.md)
 - 🪪 **DOI:** [`10.5281/zenodo.20248676`](https://doi.org/10.5281/zenodo.20248676) — see [`CITATION.cff`](CITATION.cff)
 - 📜 **Changelog:** [`CHANGELOG.md`](CHANGELOG.md)
 

--- a/docs/DATASHEET.md
+++ b/docs/DATASHEET.md
@@ -1,0 +1,62 @@
+# Datasheet — GenAI & Agentic AI Security Incidents
+
+Following *Datasheets for Datasets* (Gebru et al.). For per-field definitions see
+[`DATA_DICTIONARY.md`](DATA_DICTIONARY.md); for the formal schema see
+[`schema/incident.schema.json`](../schema/incident.schema.json).
+
+## Motivation
+A single, machine-readable source of truth for GenAI and agentic-AI security
+incidents, normalized and mapped to OWASP LLM/ASI, NIST AI RMF, and MITRE
+ATLAS — so developers, AppSec/threat-intel teams, and researchers can query,
+pivot, and cite incidents instead of re-scraping scattered trackers.
+
+## Composition
+- **Instances:** consolidated incidents (currently 7,720), each an alleged
+  real-world harm, disclosed vulnerability, threat report, or research/red-team
+  demonstration involving an AI system.
+- **Split:** `corpus` = `security` vs `ai-harm`; `category` distinguishes
+  real-world from research/red-team/regulatory entries.
+- **Labels:** severity, attack_vector, and OWASP/NIST/ATLAS mappings — assigned
+  by deterministic heuristics and, for a growing subset, human/assisted review
+  (see `quality_tier`).
+- **Provenance:** every entry records its upstream `source_ids`.
+
+## Collection
+Aggregated from public, credible sources: AI Incident Database (AIID), AIAAIC,
+OECD AI Incidents Monitor, MIT AI Risk Repository, MITRE ATLAS, AVID, NVD +
+GitHub Security Advisories + OSV.dev (AI/ML packages), OWASP, vendor threat
+reports, and peer-reviewed venues (arXiv/USENIX/CCS/NDSS). Ingestion scripts
+live in [`scripts/`](../scripts); each source is re-pulled, normalized, then
+deduplicated by CVE / canonical URL / fuzzy title.
+
+## Preprocessing & quality
+- **Dedup:** union of taxonomy/refs, highest severity, most specific date;
+  merged ids tombstoned in `id_deprecations.json`.
+- **Classification:** `attack_vector` and framework mappings are filled by
+  precision-first heuristics; `quality_tier` records vetting level.
+- **Curation overrides:** explicit human/assisted decisions are recorded in
+  [`data/curation_overrides.json`](../data/curation_overrides.json) and survive rebuilds.
+- **Reproducibility:** the full build is deterministic and idempotent across
+  calendar days (CI re-derives all outputs and fails on any drift).
+
+## Uses
+- AppSec triage and dependency/CVE lookup; threat-intel (STIX 2.1 export,
+  ATLAS tactic/technique pivots); research on AI-incident trends and taxonomy.
+- **Not** a complete census of all AI incidents, and not legal advice.
+
+## Limitations & biases
+- **Source & language bias:** English-language, Western-media-skewed; under-counts
+  unreported or non-English incidents.
+- **Heuristic labels:** `auto`-tier mappings are unreviewed; `attack_vector`
+  `other` (~39%) reflects genuinely uncategorized harm incidents.
+- **Recency lag:** very recent CVEs may lack CVSS until NVD scores them.
+- **Scope drift:** broad sources (AIAAIC/OECD) include pre-LLM algorithmic harms.
+
+## Distribution & licence
+- **Data:** CC-BY-4.0. **Code:** MIT. DOI [10.5281/zenodo.20248676](https://doi.org/10.5281/zenodo.20248676).
+- Distributed via GitHub, PyPI (`genai-incidents`), Hugging Face Datasets, and a STIX 2.1 bundle.
+
+## Maintenance
+Maintained at <https://github.com/emmanuelgjr/genai_incidents>; a weekly workflow
+refreshes external sources via PR. Versioned with SemVer; see [`CHANGELOG.md`](../CHANGELOG.md).
+Corrections welcome via issues/PRs and the curation-overrides file.

--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -1,0 +1,60 @@
+# Data dictionary
+
+Every incident in [`data/incidents.json`](../data/incidents.json) follows
+[`schema/incident.schema.json`](../schema/incident.schema.json). Fields below; **R** = required.
+
+## Identity & provenance
+| Field | Type | Notes |
+|---|---|---|
+| `id` **R** | string | Stable incident id, `INC-#####`. Never reused; merged-away ids are recorded in [`data/id_deprecations.json`](../data/id_deprecations.json) and resolvable via the package's `resolve_id()`. |
+| `source_ids` | string[] | Upstream ids this entry was consolidated from (e.g. `AIID-1234`, `CVE-2026-…`, `ATLAS-AML.CS0001`, `AIAAIC2257`). |
+| `quality_tier` | enum | Vetting level: `curated` (hand-written/maintainer), `reviewed` (maintained catalogue, NVD-scored CVE, hand-picked, or human/assisted review), `auto` (bulk-ingested). Filter on this to control trust. |
+| `corpus` | enum | `security` (exploit/vuln/misuse) or `ai-harm` (societal harm without a security primitive). |
+| `added` / `updated` | date | First-added / last-content-change dates (content-gated, so unchanged entries don't churn). |
+
+## Core description
+| Field | Type | Notes |
+|---|---|---|
+| `title` **R** | string | ≥5 chars. |
+| `description` **R** | string | ≥20 chars. |
+| `date` **R** | string | `YYYY`, `YYYY-MM`, or `YYYY-MM-DD`. |
+| `year` **R** | integer | 1980–2030. |
+| `category` **R** | enum | `real-world`, `research`, `research-demonstrated`, `red-team`, `vulnerability-disclosure`, `threat-report`, `policy`, `regulatory`, `report`. |
+| `severity` **R** | enum | `Critical`, `High`, `Medium`, `Low`, `Info`. |
+| `attack_vector` | string | Controlled vocabulary (see schema `examples`): `prompt-injection`, `rce`, `data-exfiltration`, `deepfake`, `privacy-violation`, `algorithmic-bias`, `csam-generation`, `unsafe-advice`, `other`, … |
+| `affected` | string | Vendor / product / organization / system affected (free text). |
+| `impact` | string | Real-world consequence summary. |
+
+## Framework mappings
+| Field | Type | Notes |
+|---|---|---|
+| `owasp_llm` | enum[] | OWASP Top 10 for LLM Apps 2025 — `LLM01`–`LLM10`. |
+| `owasp_asi` | enum[] | OWASP Agentic (ASI) Top 10 — `ASI01`–`ASI10`. |
+| `owasp_dsgai` | string[] | OWASP Data Security for GenAI codes (`DSGAInn`, companion). |
+| `nist_ai_rmf` | string[] | NIST AI RMF subcategories, e.g. `MEASURE-2.7`, `MAP-3.5`. |
+| `mitre_atlas` | string[] | MITRE ATLAS technique ids, e.g. `AML.T0051`, `AML.T0048.003`. |
+| `mitre_atlas_tactics` | string[] | ATLAS tactic ids, e.g. `AML.TA0011` (Impact). Derived from techniques (subtechniques inherit the parent's). |
+| `maestro_layers` | object[] | MAESTRO architectural-layer mapping (companion; `{layer, label, role, notes}`). |
+
+## Vulnerability metadata
+| Field | Type | Notes |
+|---|---|---|
+| `cve_ids` | string[] | `CVE-YYYY-NNNN…`. |
+| `cwe_ids` | string[] | `CWE-NNN`. |
+| `cvss_score` | number | 0–10. |
+| `cvss_vector` | string | Full CVSS vector string. |
+| `aiid_id` | integer | AI Incident Database numeric id where cross-listed. |
+| `disclosure_date` | string | Public disclosure date when distinct from `date`. |
+
+## Evidence
+| Field | Type | Notes |
+|---|---|---|
+| `references` **R** | object[] | ≥1 `{title, url, type}`; `type` ∈ news/advisory/research/vendor/blog/cve/report/paper/regulatory/disclosure/legal/… |
+| `mitigations` | string[] | Defensive measures / remediation. |
+| `tags` | string[] | Free-form, incl. `sector-*` and `juris-*` facets and source tags (`aiaaic`, `atlas`, …). |
+
+## Access
+- **Python:** `pip install genai-incidents` → `load_incidents()`, `query(...)`, `by_id()`, `by_cve()`, `resolve_id()`.
+- **Hugging Face:** `load_dataset("emmanuelgjr/genai-incidents")` (JSONL projection).
+- **STIX 2.1:** `…github.io/genai_incidents/data/incidents.stix.json`.
+- **CSV / min JSON / per-year markdown:** see the [site](https://emmanuelgjr.github.io/genai_incidents/) and [`docs/`](.).

--- a/scripts/export_huggingface.py
+++ b/scripts/export_huggingface.py
@@ -1,0 +1,109 @@
+"""
+Build a Hugging Face Datasets package for the incident corpus:
+
+  dist/hf/incidents.jsonl   one incident per line (load_dataset-friendly)
+  dist/hf/README.md         dataset card (YAML front matter + usage)
+
+Then optionally push to the Hub:
+
+  HF_TOKEN=...  python scripts/export_huggingface.py --push --repo <user>/genai-incidents
+
+`dist/` is a build artifact (gitignored). The JSONL is a flat projection of
+data/incidents.json["incidents"], so `datasets.load_dataset("json", ...)`
+and `load_dataset("<repo>")` both work.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA = ROOT / "data"
+OUT = ROOT / "dist" / "hf"
+
+CARD = """\
+---
+license: cc-by-4.0
+language:
+  - en
+pretty_name: GenAI & Agentic AI Security Incidents
+tags:
+  - security
+  - ai-safety
+  - llm
+  - incidents
+  - owasp
+  - mitre-atlas
+  - nist-ai-rmf
+task_categories:
+  - text-classification
+size_categories:
+  - 1K<n<10K
+configs:
+  - config_name: default
+    data_files: incidents.jsonl
+---
+
+# GenAI & Agentic AI Security Incidents
+
+{count} real-world and research GenAI / agentic-AI security incidents, each mapped to
+**OWASP LLM Top 10 (2025)**, **OWASP Agentic (ASI) Top 10**, **NIST AI RMF**, and
+**MITRE ATLAS** (techniques + tactics). Dataset version `{version}`.
+
+```python
+from datasets import load_dataset
+ds = load_dataset("{repo}", split="train")
+ds = ds.filter(lambda r: "LLM01" in (r["owasp_llm"] or []))   # prompt-injection incidents
+```
+
+- Code: <https://github.com/emmanuelgjr/genai_incidents>
+- Schema & field reference: [`docs/DATA_DICTIONARY.md`](https://github.com/emmanuelgjr/genai_incidents/blob/main/docs/DATA_DICTIONARY.md)
+- Provenance, scope & limitations: [`docs/DATASHEET.md`](https://github.com/emmanuelgjr/genai_incidents/blob/main/docs/DATASHEET.md)
+- Citation: see [`CITATION.cff`](https://github.com/emmanuelgjr/genai_incidents/blob/main/CITATION.cff) · DOI [10.5281/zenodo.20248676](https://doi.org/10.5281/zenodo.20248676)
+
+**Licence:** data CC-BY-4.0, code MIT. Each entry carries a `quality_tier`
+(`curated` / `reviewed` / `auto`) so consumers can filter by vetting level.
+"""
+
+
+def build(out_dir: Path) -> tuple[int, Path]:
+    raw = json.loads((DATA / "incidents.json").read_text(encoding="utf-8"))
+    incidents = raw.get("incidents", [])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    jsonl = out_dir / "incidents.jsonl"
+    with jsonl.open("w", encoding="utf-8", newline="\n") as fh:
+        for inc in incidents:
+            fh.write(json.dumps(inc, ensure_ascii=False, sort_keys=True) + "\n")
+    card = CARD.format(count=f"{len(incidents):,}", version=raw.get("version", "?"),
+                       repo="emmanuelgjr/genai-incidents")
+    (out_dir / "README.md").write_text(card, encoding="utf-8", newline="\n")
+    return len(incidents), jsonl
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--push", action="store_true", help="upload to the Hugging Face Hub")
+    ap.add_argument("--repo", default="emmanuelgjr/genai-incidents")
+    args = ap.parse_args()
+
+    n, jsonl = build(OUT)
+    print(f"[hf] wrote {n} records -> {jsonl} (+ README.md)")
+
+    if args.push:
+        import os
+        token = os.environ.get("HF_TOKEN")
+        if not token:
+            print("[hf] HF_TOKEN not set; skipping upload", file=sys.stderr)
+            sys.exit(1)
+        from huggingface_hub import HfApi
+        api = HfApi(token=token)
+        api.create_repo(args.repo, repo_type="dataset", exist_ok=True)
+        api.upload_folder(folder_path=str(OUT), repo_id=args.repo, repo_type="dataset")
+        print(f"[hf] pushed to https://huggingface.co/datasets/{args.repo}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_export_huggingface.py
+++ b/tests/test_export_huggingface.py
@@ -1,0 +1,22 @@
+"""Tests for the Hugging Face exporter."""
+
+from __future__ import annotations
+
+import json
+
+import export_huggingface as hf
+
+
+def test_build_emits_jsonl_and_card(tmp_path):
+    n, jsonl = hf.build(tmp_path)
+    assert jsonl.exists() and n > 0
+    lines = [l for l in jsonl.read_text(encoding="utf-8").split("\n") if l]
+    assert len(lines) == n
+    # every newline-delimited line is a valid JSON object with an id
+    ids = {json.loads(l)["id"] for l in lines}
+    assert len(ids) == n
+    # dataset card has the required HF front matter
+    card = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert card.startswith("---")
+    assert "license: cc-by-4.0" in card
+    assert "configs:" in card and "incidents.jsonl" in card


### PR DESCRIPTION
Makes the corpus first-class for **AI researchers** and documents it for every audience — the highest research-reach item from the usability review.

## What
- **`scripts/export_huggingface.py`** — builds a `load_dataset`-friendly **JSONL** projection (7,720 records, `\n`-delimited, all valid JSON) + a **dataset card** with proper HF YAML front matter (license, tags, `configs`). `--push` (with `HF_TOKEN`) uploads to the Hub. `make huggingface`.
  ```python
  from datasets import load_dataset
  ds = load_dataset("emmanuelgjr/genai-incidents", split="train")
  ```
- **`.github/workflows/huggingface.yml`** — publishes on each GitHub release via `HF_TOKEN`/`HF_REPO` secrets; **no-ops cleanly** when the secret is absent (forks don't fail).
- **`docs/DATA_DICTIONARY.md`** — every schema field documented (types, enums, access methods).
- **`docs/DATASHEET.md`** — *Datasheets for Datasets*: composition, collection, preprocessing, uses, **limitations & biases**, licence, maintenance.
- README links for HF / data dictionary / datasheet.

## Notes
- **Docs + exporter only — no data or pipeline change** (drift check unaffected). The `dist/hf/` output is a gitignored build artifact.
- Actual Hub upload needs you to add an `HF_TOKEN` repo secret (and optionally `HF_REPO`); until then the workflow just builds the artifact.

## Verification
- ✅ `pytest` → **81 passed** (1 new: JSONL shape + card front matter)
- ✅ JSONL verified: 7,720 newline-delimited records, all parse, unique ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)