### PR TITLE
Retain-on-drop: stop silently losing incidents when a source drops them

### DIFF
--- a/docs/superpowers/plans/2026-06-01-retain-on-drop.md
+++ b/docs/superpowers/plans/2026-06-01-retain-on-drop.md
@@ -274,7 +274,14 @@ git commit -m "feat(merge): add retention helpers (load_retained_priors)"
 
 ---
 
-## Task 4: Build retention — wire "step 2b" into `merge_and_dedupe.main()`
+## Task 4: Build retention — wire retention into `merge_and_dedupe.main()`
+
+> **Revised during implementation.** The "step 2b re-feed before dedupe"
+> approach below proved non-idempotent and exposed a latent dedupe bug (it
+> dropped 17 CVEs). It was reworked as a **post-build top-up (step 6c)** that
+> appends only uncovered priors *after* dedupe, verbatim. See the updated
+> `docs/superpowers/specs/2026-06-01-retain-on-drop-design.md` (Part B) and the
+> follow-up `docs/superpowers/specs/2026-06-03-dedup-tombstone-bug.md`.
 
 **Files:**
 - Modify: `scripts/merge_and_dedupe.py` — `main()`, immediately after the ingest-loading loop (currently ends ~line 814, the `print(f"[{src.name:40s}] ...")` line)

--- a/docs/superpowers/plans/2026-06-01-retain-on-drop.md
+++ b/docs/superpowers/plans/2026-06-01-retain-on-drop.md
@@ -282,6 +282,10 @@ git commit -m "feat(merge): add retention helpers (load_retained_priors)"
 > appends only uncovered priors *after* dedupe, verbatim. See the updated
 > `docs/superpowers/specs/2026-06-01-retain-on-drop-design.md` (Part B) and the
 > follow-up `docs/superpowers/specs/2026-06-03-dedup-tombstone-bug.md`.
+>
+> **The "step 2b" code block below is the ORIGINAL (superseded) approach,
+> retained only for history. The shipped implementation is the step-6c
+> post-build top-up described in the spec — do not implement the block below.**
 
 **Files:**
 - Modify: `scripts/merge_and_dedupe.py` — `main()`, immediately after the ingest-loading loop (currently ends ~line 814, the `print(f"[{src.name:40s}] ...")` line)

--- a/docs/superpowers/plans/2026-06-01-retain-on-drop.md
+++ b/docs/superpowers/plans/2026-06-01-retain-on-drop.md
@@ -1,0 +1,547 @@
+# Retain-on-drop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the pipeline from silently dropping incidents when an upstream source (notably the OECD AIM sliding-window fetch) stops returning them.
+
+**Architecture:** Two complementary changes. (A) The OECD ingester unions its fresh fetch into the committed ingest file instead of overwriting, so nothing ages out of the 3,000-URL window. (B) `merge_and_dedupe.py` re-feeds previously-published incidents (minus explicitly deprecated ids) back into the build as inputs, so the existing dedup machinery either merges them with fresh data or lets them survive — a general backstop for any source.
+
+**Tech Stack:** Python 3.12, pytest. Scripts importable via `tests/conftest.py` (which puts `scripts/` on `sys.path`, so `import merge_and_dedupe as m` and `import ingest_oecd_aim as o` work).
+
+**Determinism constraint:** The build must rebuild byte-identically across UTC days (CI drift check). Retained entries carry unchanged content, so their `_content_snapshot` matches the previous output and `_apply_history` preserves `updated` — no spurious bump. Tested explicitly in Task 5.
+
+---
+
+## File structure
+
+- `scripts/ingest_oecd_aim.py` — add pure `union_with_existing()`; call it in `main()` before writing.
+- `scripts/merge_and_dedupe.py` — add pure `_load_prev_incidents()`, `_load_deprecated_ids()`, `load_retained_priors()`; add "step 2b" in `main()` that re-feeds retained priors into `all_entries`.
+- `tests/test_ingest_oecd_aim.py` — NEW: unit tests for `union_with_existing`.
+- `tests/test_merge_and_dedupe.py` — add unit tests for `load_retained_priors` and an end-to-end retention + determinism test driving `main()` in a tmp dir.
+
+---
+
+## Task 1: OECD ingester — `union_with_existing` helper (pure function + test)
+
+**Files:**
+- Modify: `scripts/ingest_oecd_aim.py` (add function above `def main()`, ~line 271)
+- Test: `tests/test_ingest_oecd_aim.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_ingest_oecd_aim.py`:
+
+```python
+"""Unit tests for the OECD AIM ingester's union-with-existing behaviour."""
+
+from __future__ import annotations
+
+import ingest_oecd_aim as o
+
+
+def _entry(sid, title):
+    return {"source_id": sid, "title": title, "year": 2026,
+            "references": [{"url": "https://oecd.ai/en/incidents/x"}]}
+
+
+def test_union_keeps_aged_out_existing_entries():
+    # Fresh fetch lost OLD-2 (it aged out of the 3000-URL window).
+    fresh = [_entry("OECD-AIM-NEW-1", "new one")]
+    existing = [_entry("OECD-AIM-OLD-2", "old two")]
+    out = o.union_with_existing(fresh, existing)
+    ids = {e["source_id"] for e in out}
+    assert ids == {"OECD-AIM-NEW-1", "OECD-AIM-OLD-2"}
+
+
+def test_union_fresh_wins_on_conflict():
+    fresh = [_entry("OECD-AIM-1", "fresh title")]
+    existing = [_entry("OECD-AIM-1", "stale title")]
+    out = o.union_with_existing(fresh, existing)
+    assert len(out) == 1
+    assert out[0]["title"] == "fresh title"
+
+
+def test_union_output_sorted_by_source_id():
+    fresh = [_entry("OECD-AIM-3", "c"), _entry("OECD-AIM-1", "a")]
+    existing = [_entry("OECD-AIM-2", "b")]
+    out = o.union_with_existing(fresh, existing)
+    assert [e["source_id"] for e in out] == [
+        "OECD-AIM-1", "OECD-AIM-2", "OECD-AIM-3"
+    ]
+
+
+def test_union_drops_entries_without_source_id():
+    fresh = [{"title": "no id", "references": []}]
+    existing = []
+    assert o.union_with_existing(fresh, existing) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_ingest_oecd_aim.py -v`
+Expected: FAIL — `AttributeError: module 'ingest_oecd_aim' has no attribute 'union_with_existing'`
+
+- [ ] **Step 3: Add the helper**
+
+In `scripts/ingest_oecd_aim.py`, insert this function immediately above `def main():` (currently ~line 271):
+
+```python
+def union_with_existing(fresh: list[dict], existing: list[dict]) -> list[dict]:
+    """Union the fresh fetch with the previously-committed ingest file so the
+    OECD corpus only ever grows. Keyed by ``source_id`` (``OECD-AIM-<id>``):
+    fresh wins on conflict (latest content); entries present only in
+    ``existing`` (aged out of the newest-N sitemap window) are kept. Output is
+    sorted by ``source_id`` so the committed file has stable, deterministic
+    ordering."""
+    by_id: dict[str, dict] = {}
+    for e in existing:
+        sid = e.get("source_id")
+        if sid:
+            by_id[sid] = e
+    for e in fresh:
+        sid = e.get("source_id")
+        if sid:
+            by_id[sid] = e
+    return sorted(by_id.values(), key=lambda e: e.get("source_id") or "")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_ingest_oecd_aim.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ingest_oecd_aim.py tests/test_ingest_oecd_aim.py
+git commit -m "feat(ingest): add union_with_existing helper for OECD AIM"
+```
+
+---
+
+## Task 2: OECD ingester — wire union into `main()`
+
+**Files:**
+- Modify: `scripts/ingest_oecd_aim.py` — the write block at the end of `main()` (currently lines ~320-322)
+
+- [ ] **Step 1: Replace the overwrite with a union-then-write**
+
+In `scripts/ingest_oecd_aim.py`, the current tail of `main()` reads:
+
+```python
+    out_path = INGEST / "oecd_aim_full_incidents.json"
+    out_path.write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
+    print(f"[aim] wrote -> {out_path}")
+```
+
+Replace it with:
+
+```python
+    out_path = INGEST / "oecd_aim_full_incidents.json"
+    existing: list[dict] = []
+    if out_path.exists():
+        try:
+            existing = json.loads(out_path.read_text(encoding="utf-8"))
+            if not isinstance(existing, list):
+                existing = []
+        except (json.JSONDecodeError, OSError):
+            existing = []
+    merged = union_with_existing(out, existing)
+    print(
+        f"[aim] union: {len(out)} fetched + {len(existing)} existing "
+        f"-> {len(merged)} retained"
+    )
+    out_path.write_text(
+        json.dumps(merged, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+    print(f"[aim] wrote -> {out_path}")
+```
+
+(The trailing newline matches the merge/render writers, which use `newline="\n"` plus a final newline, keeping the committed file POSIX-clean.)
+
+- [ ] **Step 2: Sanity-check the module still imports and tests pass**
+
+Run: `python -c "import sys; sys.path.insert(0,'scripts'); import ingest_oecd_aim"`
+Expected: no output, exit 0.
+
+Run: `python -m pytest tests/test_ingest_oecd_aim.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/ingest_oecd_aim.py
+git commit -m "feat(ingest): OECD AIM unions fetch into committed file (no more aging-out)"
+```
+
+---
+
+## Task 3: Build retention — pure helpers (`load_retained_priors`, loaders) + tests
+
+**Files:**
+- Modify: `scripts/merge_and_dedupe.py` — add three helpers near `_load_prev_state` (~line 645-728)
+- Test: `tests/test_merge_and_dedupe.py` — add unit tests
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_merge_and_dedupe.py`:
+
+```python
+def test_load_retained_priors_excludes_deprecated():
+    prev = [
+        {"id": "INC-00001", "title": "kept"},
+        {"id": "INC-00002", "title": "deprecated"},
+    ]
+    out = m.load_retained_priors(prev, {"INC-00002"})
+    assert [e["id"] for e in out] == ["INC-00001"]
+
+
+def test_load_retained_priors_keeps_all_when_none_deprecated():
+    prev = [{"id": "INC-00001"}, {"id": "INC-00002"}]
+    out = m.load_retained_priors(prev, set())
+    assert len(out) == 2
+
+
+def test_load_retained_priors_skips_entries_without_id():
+    prev = [{"title": "no id"}, {"id": "INC-00003", "title": "ok"}]
+    out = m.load_retained_priors(prev, set())
+    assert [e["id"] for e in out] == ["INC-00003"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python -m pytest tests/test_merge_and_dedupe.py -k load_retained_priors -v`
+Expected: FAIL — `AttributeError: module 'merge_and_dedupe' has no attribute 'load_retained_priors'`
+
+- [ ] **Step 3: Add the helpers**
+
+In `scripts/merge_and_dedupe.py`, immediately after the `_load_curation_overrides()` function (ends ~line 664, just before `def _load_prev_state(`), add:
+
+```python
+def _load_prev_incidents() -> list[dict]:
+    """Read the previously-published incidents list (empty if none yet)."""
+    prev_path = DATA / "incidents.json"
+    if not prev_path.exists():
+        return []
+    try:
+        return json.loads(prev_path.read_text(encoding="utf-8")).get("incidents", [])
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def _load_deprecated_ids() -> set[str]:
+    """Ids that were explicitly retired via merge/dedupe. These must never be
+    resurrected by retention."""
+    if not DEPRECATIONS_PATH.exists():
+        return set()
+    try:
+        deprec = json.loads(DEPRECATIONS_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return set()
+    return {d.get("from") for d in deprec.get("deprecations", []) if d.get("from")}
+
+
+def load_retained_priors(
+    prev_incidents: list[dict], deprecated_ids: set[str]
+) -> list[dict]:
+    """Select previously-published incidents to carry forward into the build.
+
+    Every prior incident is re-fed as a build input EXCEPT those whose id was
+    explicitly deprecated (merged away). When re-run through dedupe, a prior
+    that still has a live source merges into the fresh entry; a prior with no
+    live source survives on its own — so the dataset never silently drops an
+    incident just because an upstream feed stopped returning it."""
+    out: list[dict] = []
+    for e in prev_incidents:
+        eid = e.get("id")
+        if not eid or eid in deprecated_ids:
+            continue
+        out.append(e)
+    return out
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python -m pytest tests/test_merge_and_dedupe.py -k load_retained_priors -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/merge_and_dedupe.py tests/test_merge_and_dedupe.py
+git commit -m "feat(merge): add retention helpers (load_retained_priors)"
+```
+
+---
+
+## Task 4: Build retention — wire "step 2b" into `merge_and_dedupe.main()`
+
+**Files:**
+- Modify: `scripts/merge_and_dedupe.py` — `main()`, immediately after the ingest-loading loop (currently ends ~line 814, the `print(f"[{src.name:40s}] ...")` line)
+
+- [ ] **Step 1: Insert the retention step**
+
+In `scripts/merge_and_dedupe.py`, find the end of step 2 in `main()`:
+
+```python
+    # 2) Each ingest/*.json (from subagents)
+    if INGEST.exists():
+        for src in sorted(INGEST.glob("*.json")):
+            raw = load_source(src)
+            kept = []
+            for r in raw:
+                norm = normalize_entry(r)
+                if norm is not None:
+                    kept.append(norm)
+            all_entries.extend(kept)
+            print(f"[{src.name:40s}] {len(raw):4d} raw -> {len(kept):4d} normalized")
+```
+
+Directly AFTER that block (before "# 3) Dedupe"), insert:
+
+```python
+    # 2b) Retention backstop: re-feed previously-published incidents (minus
+    #     explicitly deprecated ids) as build inputs. Appended AFTER the ingest
+    #     feeds so a prior that still has a live source merges INTO the fresh
+    #     entry (fresh content wins); a prior with no live source survives.
+    #     This makes the dataset archival — no source dropping an entry can
+    #     silently delete it. See docs/superpowers/specs/2026-06-01-retain-on-drop-design.md
+    prev_incidents = _load_prev_incidents()
+    retained = load_retained_priors(prev_incidents, _load_deprecated_ids())
+    kept_prior = []
+    for r in retained:
+        norm = normalize_entry(r)
+        if norm is not None:
+            kept_prior.append(norm)
+    all_entries.extend(kept_prior)
+    print(f"[retention] re-fed {len(kept_prior)} prior incident(s) as inputs")
+```
+
+- [ ] **Step 2: Verify the module imports**
+
+Run: `python -c "import sys; sys.path.insert(0,'scripts'); import merge_and_dedupe"`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Run the existing merge unit tests (no regressions)**
+
+Run: `python -m pytest tests/test_merge_and_dedupe.py -v`
+Expected: PASS (all existing + the 3 new helper tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/merge_and_dedupe.py
+git commit -m "feat(merge): retention step re-feeds prior incidents into build"
+```
+
+---
+
+## Task 5: End-to-end retention + determinism test
+
+**Files:**
+- Test: `tests/test_merge_and_dedupe.py` — add an end-to-end test that drives `main()` against a temp `data/` + `ingest/`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_merge_and_dedupe.py`:
+
+```python
+import datetime
+import json as _json
+from pathlib import Path as _Path
+
+
+class _FrozenDate(datetime.date):
+    """date subclass whose today() is pinned, for cross-day determinism tests."""
+    _pinned = datetime.date(2099, 6, 1)
+
+    @classmethod
+    def today(cls):
+        return cls._pinned
+
+
+def _oecd_entry(sid, title):
+    return {
+        "source_id": sid,
+        "title": title,
+        "description": "A description long enough to pass the minimum length filter.",
+        "year": 2026,
+        "date": "2026-04-01",
+        "attack_vector": "deepfake",
+        "severity": "High",
+        "references": [{"url": f"https://oecd.ai/en/incidents/{sid}"}],
+        "tags": ["oecd-aim"],
+    }
+
+
+def _setup_tmp_repo(tmp_path, monkeypatch):
+    data = tmp_path / "data"
+    ingest = tmp_path / "ingest"
+    data.mkdir()
+    ingest.mkdir()
+    monkeypatch.setattr(m, "DATA", data)
+    monkeypatch.setattr(m, "INGEST", ingest)
+    monkeypatch.setattr(m, "DEPRECATIONS_PATH", data / "id_deprecations.json")
+    monkeypatch.setattr(m, "CURATION_OVERRIDES_PATH", data / "curation_overrides.json")
+    return data, ingest
+
+
+def test_retention_keeps_dropped_incident_with_stable_id(tmp_path, monkeypatch):
+    data, ingest = _setup_tmp_repo(tmp_path, monkeypatch)
+
+    # First build: source emits two incidents.
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-A", "Incident A"),
+         _oecd_entry("OECD-AIM-B", "Incident B")]
+    ), encoding="utf-8")
+    m.main()
+    first = _json.loads((data / "incidents.json").read_text(encoding="utf-8"))
+    id_by_src = {
+        s: e["id"] for e in first["incidents"] for s in e["source_ids"]
+    }
+    assert {"OECD-AIM-A", "OECD-AIM-B"} <= set(id_by_src)
+    b_id = id_by_src["OECD-AIM-B"]
+
+    # Second build: source dropped incident B (aged out / removed upstream).
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-A", "Incident A")]
+    ), encoding="utf-8")
+    m.main()
+    second = _json.loads((data / "incidents.json").read_text(encoding="utf-8"))
+    src_ids_second = {s for e in second["incidents"] for s in e["source_ids"]}
+
+    # B is retained, with the SAME id it had before.
+    assert "OECD-AIM-B" in src_ids_second, "dropped incident must be retained"
+    b_id_second = next(
+        e["id"] for e in second["incidents"] if "OECD-AIM-B" in e["source_ids"]
+    )
+    assert b_id_second == b_id
+
+
+def test_deprecated_id_is_not_resurrected(tmp_path, monkeypatch):
+    data, ingest = _setup_tmp_repo(tmp_path, monkeypatch)
+    # Prior output contains INC-09999, which is recorded as deprecated.
+    (data / "incidents.json").write_text(_json.dumps({
+        "incidents": [{
+            **m.normalize_entry(_oecd_entry("OECD-AIM-DEAD", "Dead dup")),
+            "id": "INC-09999", "added": "2026-01-01", "updated": "2026-01-01",
+        }]
+    }), encoding="utf-8")
+    (data / "id_deprecations.json").write_text(_json.dumps({
+        "deprecations": [{"from": "INC-09999", "into": "INC-00001",
+                          "reason": "merged", "date": "2026-01-01"}]
+    }), encoding="utf-8")
+    # Current ingest has one live incident.
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-LIVE", "Live incident")]
+    ), encoding="utf-8")
+    m.main()
+    out = _json.loads((data / "incidents.json").read_text(encoding="utf-8"))
+    src_ids = {s for e in out["incidents"] for s in e["source_ids"]}
+    assert "OECD-AIM-DEAD" not in src_ids, "deprecated entry must not be resurrected"
+
+
+def test_build_is_deterministic_across_days(tmp_path, monkeypatch):
+    data, ingest = _setup_tmp_repo(tmp_path, monkeypatch)
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-A", "Incident A"),
+         _oecd_entry("OECD-AIM-B", "Incident B")]
+    ), encoding="utf-8")
+
+    # Build on "day 1".
+    monkeypatch.setattr(m, "date", _FrozenDate)
+    _FrozenDate._pinned = datetime.date(2099, 6, 1)
+    m.main()
+    day1 = (data / "incidents.json").read_text(encoding="utf-8")
+
+    # Rebuild on a LATER calendar day with identical inputs.
+    _FrozenDate._pinned = datetime.date(2099, 6, 2)
+    m.main()
+    day2 = (data / "incidents.json").read_text(encoding="utf-8")
+
+    assert day1 == day2, "rebuild on a later UTC day must be byte-identical"
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `python -m pytest tests/test_merge_and_dedupe.py -k "retention or deprecated or deterministic" -v`
+Expected: PASS (3 passed). If `test_build_is_deterministic_across_days` fails, a content field is being finalized after `_apply_history` snapshots it — re-examine step ordering in `main()` (steps 4b/4c/4d must run before step 5).
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `python -m pytest tests -q`
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/test_merge_and_dedupe.py
+git commit -m "test(merge): end-to-end retention, deprecation, and cross-day determinism"
+```
+
+---
+
+## Task 6: Validate against real data (PR #18 scenario) + full rebuild
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Record the current real incident count**
+
+Run:
+```bash
+python -c "import json;d=json.load(open('data/incidents.json',encoding='utf-8'));print('before:',d['incident_count'])"
+```
+Expected: prints `before: 7725` (or current count on main).
+
+- [ ] **Step 2: Full rebuild with retention active**
+
+Run:
+```bash
+python scripts/parse_existing.py
+python scripts/merge_and_dedupe.py
+python scripts/render_markdown.py
+python scripts/validate.py
+```
+Expected: `validate.py` exits 0. The `[retention] re-fed N prior incident(s)` line prints N ≈ the prior count.
+
+- [ ] **Step 3: Confirm no incidents were lost**
+
+Run:
+```bash
+python -c "import json;d=json.load(open('data/incidents.json',encoding='utf-8'));print('after:',d['incident_count'])"
+```
+Expected: `after:` count is >= the `before:` count (retention never shrinks the dataset on a no-new-source rebuild).
+
+- [ ] **Step 4: Confirm idempotency (consecutive builds are identical)**
+
+Snapshot the current output, rebuild, and diff the two consecutive builds
+against each other (NOT against committed `main` — a one-time diff vs. `main`
+is expected and is the actual fix):
+```bash
+cp data/incidents.json /tmp/inc_run1.json
+python scripts/merge_and_dedupe.py
+python -c "import sys;a=open('/tmp/inc_run1.json',encoding='utf-8').read();b=open('data/incidents.json',encoding='utf-8').read();print('IDEMPOTENT' if a==b else 'DRIFT');sys.exit(0 if a==b else 1)"
+```
+Expected: prints `IDEMPOTENT`, exit 0 — the first rebuild already reached the fixed point.
+
+- [ ] **Step 5: Run the full test suite once more**
+
+Run: `python -m pytest tests -q`
+Expected: all green.
+
+- [ ] **Step 6: Commit the regenerated data outputs**
+
+```bash
+git add data/incidents.json data/incidents.min.json data/id_deprecations.json INCIDENTS.md docs/
+git commit -m "chore(data): rebuild outputs with retention active"
+```
+
+(If `git status` shows no changes here because retention produced no net difference on current `main`, skip this commit — note that in the PR description.)
+
+---
+
+## Rollout (after all tasks pass)
+
+1. Push `retain-on-drop`, open a PR, `gh pr checks --watch` until green, squash-merge, pull `main` (per `working-style-pr-cadence`).
+2. Close stale refresh PR #18 (its branch predates this change) and re-run the **Weekly auto-refresh** workflow so the next refresh PR is built on the retentive pipeline.
+3. Future follow-up (separate PR, not now): `source_status` / `last_seen` provenance field to distinguish live-in-feed vs. retained-but-dropped.

--- a/docs/superpowers/specs/2026-06-01-retain-on-drop-design.md
+++ b/docs/superpowers/specs/2026-06-01-retain-on-drop-design.md
@@ -1,0 +1,141 @@
+# Retain-on-drop for the genai_incidents pipeline
+
+**Date:** 2026-06-01
+**Status:** Approved (design); pending implementation
+**Author:** maintainer + Claude Code
+
+## Problem
+
+The weekly auto-refresh silently loses incidents. The 2026-05-31 refresh PR
+(#18) showed a net change of +5 (7,725 → 7,730) that masked **245 added /
+240 removed** entries. Investigation confirmed the removals are not dedupe
+merges (only 6 of 240 are recorded in `id_deprecations.json`) and the dropped
+incidents do not reappear under any other id — they are genuinely gone. Several
+are substantive real-world events (Waymo robotaxi recall, Tesla Autopilot
+fatalities, etc.).
+
+### Root cause (confirmed in code)
+
+1. **The OECD ingester is a sliding window.** `scripts/ingest_oecd_aim.py`
+   fetches only the newest `DEFAULT_LIMIT = 3000` sitemap URLs (the
+   `Weekly auto-refresh` workflow passes `3000`) and **overwrites** the
+   committed `ingest/oecd_aim_full_incidents.json` with just that fetch. The
+   security-relevant OECD corpus exceeds 3,000 entries, so on each run the
+   oldest entries fall outside the window and are erased from the committed
+   ingest file.
+2. **The build is not retentive.** `scripts/merge_and_dedupe.py` rebuilds
+   `data/incidents.json` purely from `ingest/*.json` + `legacy_consolidated.json`.
+   The previous `data/incidents.json` is read **only** for timestamp/id
+   stability (`_load_prev_state`), never as a retention source. Anything missing
+   from the current ingest files vanishes.
+
+Net effect: as the OECD window slides, ~235 incidents/week silently disappear.
+
+## Goal & semantics
+
+Make the dataset **archival**: once an incident is published in
+`data/incidents.json`, it is never silently dropped because an upstream source
+stopped returning it. Incidents leave the dataset **only** via the existing
+explicit deprecation/merge path (`id_deprecations.json`).
+
+Two complementary fixes (both, per maintainer decision):
+
+- **Part A** stops the loss at the source (OECD ingest file accumulates).
+- **Part B** is a general backstop for *any* source that drops entries.
+
+Out of scope (deliberate future follow-up): a `source_status` / `last_seen`
+provenance field to distinguish "live in upstream feed" from "retained but
+upstream no longer lists it." That requires per-entry last-seen tracking, which
+collides with the cross-day determinism rule and spans the schema, validator,
+and exports — it deserves its own focused PR.
+
+## Part A — OECD ingester union (`scripts/ingest_oecd_aim.py`)
+
+Extract the write step into a pure helper and union the fresh fetch with the
+committed file instead of overwriting:
+
+```
+def union_with_existing(fresh: list[dict], existing: list[dict]) -> list[dict]:
+    """Union by source_id. Fresh wins on conflict; aged-out entries survive.
+    Output sorted by source_id for a deterministic, stable-ordered file."""
+```
+
+- Key on `source_id` (`OECD-AIM-<id>`).
+- Entry in both → take the **fresh** version (latest content).
+- Entry only in `existing` (aged out of the window) → **keep it**.
+- Sort output by `source_id` so the committed file ordering is stable.
+
+`main()` loads the existing committed file (if present), calls
+`union_with_existing(out, existing)`, and writes the union. Result: the
+committed OECD ingest file only grows; nothing ages out.
+
+## Part B — build-level retention backstop (`scripts/merge_and_dedupe.py`)
+
+Add **step 2b** in `main()`, immediately after the ingest files are loaded
+(step 2) and before dedupe (step 3):
+
+1. Read the previous `data/incidents.json` (reuse the already-open read in
+   `_load_prev_state` or read once and pass through).
+2. Build the deprecations `from`-set from `id_deprecations.json`.
+3. For each prior incident whose `id` is **not** in the deprecations set,
+   append it to `all_entries`.
+
+The existing dedup machinery then handles everything:
+
+- A prior incident that also appears in a fresh ingest matches on
+  `source_id` / CVE / URL / title and **merges**. Ingest entries are appended
+  *before* priors, so the fresh entry is the dedup survivor and the prior merges
+  into it (fresh content wins).
+- A prior incident with no fresh match **survives on its own**.
+
+Prior entries flow through the **same** normalize → finalize-vector →
+seed-frameworks → curation-overrides → `_apply_history` path as everything else,
+so a retained entry is treated identically to a freshly-ingested one.
+
+### Determinism (the critical constraint)
+
+The build must rebuild byte-identically across UTC days (see
+`pipeline-determinism`). Retention is safe because:
+
+- A retained entry's content is unchanged from the previous output, so its
+  `_content_snapshot` matches the stored snapshot and `_apply_history` preserves
+  `updated` — no spurious bump, no `generated` flap, drift check stays clean.
+- Idempotent: feeding the output back in produces the same set of survivors.
+- Deterministic ordering: priors are appended in their stored order (stable by
+  `id`); fresh-vs-prior conflicts always resolve to the fresh survivor.
+
+This is the area to test hardest, given the prior `attack_vector`-before-
+`_apply_history` determinism bug.
+
+## Testing
+
+- **Retention:** remove an entry from an ingest fixture, rebuild, assert the
+  entry persists in `data/incidents.json` with the **same** `INC-` id.
+- **Deprecation still wins:** an id present in `id_deprecations.json` `from` is
+  **not** resurrected by retention.
+- **Ingester union:** unit-test `union_with_existing` directly (pure function,
+  no network) — aged-out entry survives, shared entry takes fresh content,
+  output is sorted by `source_id`.
+- **Determinism:** build twice and with a faked future `date.today()`; assert
+  zero field diffs and stable `generated`.
+
+## Validation against PR #18
+
+After the change, re-running the refresh flow on current `main` must **retain**
+the ~235 OECD incidents that PR #18 would have dropped, rather than losing them.
+Verify concretely (rebuild, diff incident-id set vs. main) before claiming done.
+
+## Files touched
+
+- `scripts/ingest_oecd_aim.py` — extract + call `union_with_existing`.
+- `scripts/merge_and_dedupe.py` — add step 2b (retention backstop).
+- `tests/` — new retention, deprecation, union, and determinism tests.
+
+No schema, export (STIX/HF), or docs changes — retention is silent in v1.
+
+## Rollout
+
+Ship as a focused PR: branch → push → watch CI green → squash-merge → pull main
+(per `working-style-pr-cadence`). Then re-run the weekly auto-refresh so the
+next refresh PR is built on the retentive pipeline. Close the stale PR #18 and
+re-run rather than merging it (its branch predates this change).

--- a/docs/superpowers/specs/2026-06-01-retain-on-drop-design.md
+++ b/docs/superpowers/specs/2026-06-01-retain-on-drop-design.md
@@ -71,41 +71,60 @@ committed OECD ingest file only grows; nothing ages out.
 
 ## Part B — build-level retention backstop (`scripts/merge_and_dedupe.py`)
 
-Add **step 2b** in `main()`, immediately after the ingest files are loaded
-(step 2) and before dedupe (step 3):
+> **Design revised during implementation.** The original plan re-fed prior
+> incidents into `all_entries` *before* dedupe (a "step 2b"). Implementation
+> testing showed that re-running already-built records through the raw-ingest
+> dedupe is **non-idempotent** — the build oscillated (7725 → 7719 → 7725) and
+> **silently dropped 17 CVEs** by exposing a latent dedupe bug (see "Discovered
+> bug" below). The retention was therefore reworked as a **post-build top-up**
+> that bypasses dedupe entirely.
 
-1. Read the previous `data/incidents.json` (reuse the already-open read in
-   `_load_prev_state` or read once and pass through).
-2. Build the deprecations `from`-set from `id_deprecations.json`.
-3. For each prior incident whose `id` is **not** in the deprecations set,
-   append it to `all_entries`.
+Add **step 6c** in `main()`, *after* IDs are assigned (step 6) and *before*
+`generated` is computed (step 7):
 
-The existing dedup machinery then handles everything:
+1. Compute `covered_keys` — every `source_id` + `cve_id` present in the
+   freshly-built `surviving` set.
+2. For each prior incident from `load_retained_priors(...)` (i.e. not
+   explicitly deprecated): if **none** of its `source_id`/`cve_id` keys are in
+   `covered_keys` (and its id isn't already used), the fresh build no longer
+   represents it → append it **verbatim** to `surviving`, keeping its `id`,
+   `added`, and `updated`. Otherwise skip it (already represented).
 
-- A prior incident that also appears in a fresh ingest matches on
-  `source_id` / CVE / URL / title and **merges**. Ingest entries are appended
-  *before* priors, so the fresh entry is the dedup survivor and the prior merges
-  into it (fresh content wins).
-- A prior incident with no fresh match **survives on its own**.
+Key properties:
 
-Prior entries flow through the **same** normalize → finalize-vector →
-seed-frameworks → curation-overrides → `_apply_history` path as everything else,
-so a retained entry is treated identically to a freshly-ingested one.
+- The fresh ingest→dedupe build is **untouched** — byte-identical to the
+  pre-retention pipeline. Retention only *adds* uncovered priors.
+- A carried prior is preserved exactly as last published (not re-normalised,
+  re-classified, or re-deduped), which is the correct archival semantic.
+- A prior still emitted by any source is covered by the fresh build, so it is
+  **not** duplicated.
 
 ### Determinism (the critical constraint)
 
 The build must rebuild byte-identically across UTC days (see
-`pipeline-determinism`). Retention is safe because:
+`pipeline-determinism`). The top-up is safe because:
 
-- A retained entry's content is unchanged from the previous output, so its
-  `_content_snapshot` matches the stored snapshot and `_apply_history` preserves
-  `updated` — no spurious bump, no `generated` flap, drift check stays clean.
-- Idempotent: feeding the output back in produces the same set of survivors.
-- Deterministic ordering: priors are appended in their stored order (stable by
-  `id`); fresh-vs-prior conflicts always resolve to the fresh survivor.
+- The fresh build is deterministic exactly as before (unchanged code path).
+- A carried prior keeps its stored `added`/`updated` (not today's date), so it
+  never triggers an `updated` bump or a `generated` flap.
+- Idempotent: on the next rebuild the carried prior is still uncovered (its
+  source is still gone) → carried again, same id/timestamps → identical output.
+  Verified on real data: 3 consecutive rebuilds are byte-identical and equal to
+  the pre-change committed output (retention carries 0 until a source actually
+  drops something).
 
-This is the area to test hardest, given the prior `attack_vector`-before-
-`_apply_history` determinism bug.
+### Discovered bug (pre-existing, deferred to a follow-up PR)
+
+The dedupe indexes (`by_title`, and partially `by_cve`/`by_src`/`by_url`) can
+hold references to **tombstoned** entries: `by_title` is never updated on a
+transitive merge, and `_reindex` iterates a stale list snapshot so it misses
+keys newly absorbed by `merge_into`. A later entry that matches such a stale key
+is `merge_into`'d a dead entry and its content is silently dropped. This is
+reproducible with a 4-entry ingest fixture and **no retention**, so it is a
+latent core-dedupe bug — retention merely amplified it. It is dormant on current
+real data (the committed build is stable and lossless). **Decision: ship the
+safe top-up now; fix the core dedupe bug in a separate focused PR** (see
+`docs/superpowers/specs/2026-06-03-dedup-tombstone-bug.md`).
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-03-dedup-tombstone-bug.md
+++ b/docs/superpowers/specs/2026-06-03-dedup-tombstone-bug.md
@@ -1,0 +1,95 @@
+# Core dedupe bug: content lost when merging into tombstoned entries
+
+**Date:** 2026-06-03
+**Status:** Identified + evidenced; fix deferred to its own PR
+**Discovered by:** the retain-on-drop work (see
+`2026-06-01-retain-on-drop-design.md`), which amplified this latent bug.
+
+## Summary
+
+`scripts/merge_and_dedupe.py`'s dedupe can **silently drop incident content**
+(observed: 17 CVEs across 6 incidents during a retention build) by merging a
+new entry into an entry that was already *tombstoned* (absorbed by a transitive
+merge). The dead entry is discarded in step 4, taking the just-merged content
+with it.
+
+This is a **pre-existing** core-dedupe defect — reproducible without the
+retention feature — but it is **dormant on current real ingest data** (the
+committed build is stable at 7725 with no loss). It only manifests when many
+key-sharing records flow through dedupe, which the (since-reworked) "re-feed
+priors through dedupe" approach did at scale.
+
+## Root cause
+
+The dedupe keeps four indexes: `by_cve`, `by_src`, `by_url`, `by_title`. When
+`_reindex` finds a key already owned by a different deduped entry, it does a
+transitive merge: `merge_into(target, other)` then `other["_tombstoned"] = True`.
+Two staleness problems leave indexes pointing at tombstoned entries:
+
+1. **`by_title` is never updated by `_reindex`** (it only touches
+   `by_cve`/`by_src`/`by_url`). After `other` is tombstoned, `by_title[tk]` can
+   still point to it.
+2. **`_reindex` iterates a stale snapshot.** `for c in target.get("cve_ids")`
+   captures the list object once; `merge_into` reassigns `target["cve_ids"]` to
+   a new list, so keys newly absorbed from `other` are **not** re-claimed to
+   `target` in that pass. Those keys keep pointing at the now-tombstoned `other`.
+
+Later, an entry whose only match is one of these stale keys takes the
+`merge_into(<dead entry>, e)` path (the dedupe branches don't check
+`_tombstoned`). `e` is not appended to `deduped`; the dead entry is dropped in
+step 4 → `e`'s content is lost.
+
+Evidence from a retention build (diagnostic instrumentation, since reverted):
+```
+by_title -> tombstoned: 153
+by_cve   -> tombstoned: 49
+by_src   -> tombstoned: 226
+by_url   -> tombstoned: 807
+orphaned-tombstoned entries w/ lost CVEs: 4–6 (varied run to run → non-idempotent)
+```
+
+## Minimal reproduction (no retention)
+
+Four ingest entries, in order:
+
+- `A {source_id: S-A, title: "Alpha", refs:[urlA]}` → new survivor.
+- `B {source_id: S-B, cve: [CVE-7001], title: "Beta", refs:[urlB]}` → new survivor.
+- `C {source_id: [S-A, S-B], title: "Gamma", refs:[urlC]}` → merges into A via
+  `S-A`; `_reindex(A)` then claims `S-B` (owned by B) → **B tombstoned**, but
+  `by_title["beta"]` still points at B.
+- `D {source_id: S-D, cve: [CVE-7002], title: "Beta"}` → no cve/src/url hit;
+  title hit `by_title["beta"]` = tombstoned B → `merge_into(B, D)` → B dropped →
+  **CVE-7002 lost.**
+
+A test asserting `CVE-7002` is present in the output **fails** on current code.
+
+## Proposed fix (for the PR)
+
+Make dedupe never operate on a tombstoned entry by resolving to the live
+absorber:
+
+1. When tombstoning, record the absorber: `other["_merged_into"] = target`.
+2. Add `_live(entry)`: follow `_merged_into` while `_tombstoned`, with a cycle
+   guard, returning the live root.
+3. In every dedupe branch, resolve the hit with `_live(...)` before
+   `merge_into`. In the title branch, resolve before the year check.
+4. In `_claim`, resolve `other` via `_live` before comparing/merging, and make
+   `_reindex` re-claim against `target`'s **current** keys until the key set
+   stops growing (loop-until-stable), so absorbed keys are always re-pointed at
+   the live target.
+
+### Tests
+- The 4-entry fixture above (asserts no CVE lost) — must fail before, pass after.
+- Idempotency: building twice over a fixture that forces transitive merges is
+  byte-stable.
+- Full real-data rebuild: `incident_count` does not drop, no CVE set shrinks,
+  and the build stays idempotent + cross-day stable (drift check green). Any
+  change to the committed baseline must be explainable as **recovered**
+  previously-lost content, not new loss.
+
+## Why deferred
+
+Fixing the central dedupe is delicate and could shift existing groupings; it
+deserves its own focused PR with full determinism re-validation, rather than
+being bundled into the retain-on-drop change (which is safe on its own because
+its top-up bypasses dedupe entirely).

--- a/scripts/ingest_oecd_aim.py
+++ b/scripts/ingest_oecd_aim.py
@@ -337,7 +337,22 @@ def main():
     )
 
     out_path = INGEST / "oecd_aim_full_incidents.json"
-    out_path.write_text(json.dumps(out, indent=2, ensure_ascii=False), encoding="utf-8")
+    existing: list[dict] = []
+    if out_path.exists():
+        try:
+            existing = json.loads(out_path.read_text(encoding="utf-8"))
+            if not isinstance(existing, list):
+                existing = []
+        except (json.JSONDecodeError, OSError):
+            existing = []
+    merged = union_with_existing(out, existing)
+    print(
+        f"[aim] union: {len(out)} fetched + {len(existing)} existing "
+        f"-> {len(merged)} retained"
+    )
+    out_path.write_text(
+        json.dumps(merged, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
     print(f"[aim] wrote -> {out_path}")
 
 

--- a/scripts/ingest_oecd_aim.py
+++ b/scripts/ingest_oecd_aim.py
@@ -343,15 +343,17 @@ def main():
             existing = json.loads(out_path.read_text(encoding="utf-8"))
             if not isinstance(existing, list):
                 existing = []
-        except (json.JSONDecodeError, OSError):
+        except (ValueError, OSError):
             existing = []
     merged = union_with_existing(out, existing)
     print(
-        f"[aim] union: {len(out)} fetched + {len(existing)} existing "
+        f"[aim] union: {len(out)} kept + {len(existing)} existing "
         f"-> {len(merged)} retained"
     )
     out_path.write_text(
-        json.dumps(merged, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        json.dumps(merged, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
     )
     print(f"[aim] wrote -> {out_path}")
 

--- a/scripts/ingest_oecd_aim.py
+++ b/scripts/ingest_oecd_aim.py
@@ -269,6 +269,25 @@ def normalize_body(body: dict, url: str) -> dict | None:
     }
 
 
+def union_with_existing(fresh: list[dict], existing: list[dict]) -> list[dict]:
+    """Union the fresh fetch with the previously-committed ingest file so the
+    OECD corpus only ever grows. Keyed by ``source_id`` (``OECD-AIM-<id>``):
+    fresh wins on conflict (latest content); entries present only in
+    ``existing`` (aged out of the newest-N sitemap window) are kept. Output is
+    sorted by ``source_id`` so the committed file has stable, deterministic
+    ordering."""
+    by_id: dict[str, dict] = {}
+    for e in existing:
+        sid = e.get("source_id")
+        if sid:
+            by_id[sid] = e
+    for e in fresh:
+        sid = e.get("source_id")
+        if sid:
+            by_id[sid] = e
+    return sorted(by_id.values(), key=lambda e: e.get("source_id") or "")
+
+
 def main():
     limit_env = os.environ.get("OECD_AIM_LIMIT", str(DEFAULT_LIMIT))
     try:

--- a/scripts/ingest_oecd_aim.py
+++ b/scripts/ingest_oecd_aim.py
@@ -275,7 +275,7 @@ def union_with_existing(fresh: list[dict], existing: list[dict]) -> list[dict]:
     fresh wins on conflict (latest content); entries present only in
     ``existing`` (aged out of the newest-N sitemap window) are kept. Output is
     sorted by ``source_id`` so the committed file has stable, deterministic
-    ordering."""
+    ordering (lexicographic by source_id; OECD ids are date/hash-suffixed strings, not bare integers)."""
     by_id: dict[str, dict] = {}
     for e in existing:
         sid = e.get("source_id")

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -693,13 +693,10 @@ def _load_deprecated_ids() -> set[str]:
 def load_retained_priors(
     prev_incidents: list[dict], deprecated_ids: set[str]
 ) -> list[dict]:
-    """Select previously-published incidents to carry forward into the build.
-
-    Every prior incident is re-fed as a build input EXCEPT those whose id was
-    explicitly deprecated (merged away). When re-run through dedupe, a prior
-    that still has a live source merges into the fresh entry; a prior with no
-    live source survives on its own — so the dataset never silently drops an
-    incident just because an upstream feed stopped returning it."""
+    """Return previously-published incidents eligible for retention: all priors
+    that have an id and were NOT explicitly deprecated. This applies only the
+    deprecation filter; the caller (the step 6c top-up in main) decides which of
+    these the fresh build no longer covers and appends those verbatim."""
     out: list[dict] = []
     for e in prev_incidents:
         eid = e.get("id")
@@ -1048,8 +1045,9 @@ def main():
     for e in surviving:
         covered_keys.update(e.get("cve_ids") or [])
         covered_keys.update(e.get("source_ids") or [])
+    eligible = load_retained_priors(_load_prev_incidents(), _load_deprecated_ids())
     carried = 0
-    for prior in load_retained_priors(_load_prev_incidents(), _load_deprecated_ids()):
+    for prior in eligible:
         pid = prior.get("id")
         keys = set(prior.get("cve_ids") or []) | set(prior.get("source_ids") or [])
         if not keys or (keys & covered_keys) or pid in used_ids:
@@ -1058,7 +1056,7 @@ def main():
         covered_keys.update(keys)
         used_ids.add(pid)
         carried += 1
-    print(f"[retention] carried forward {carried} prior incident(s) no longer in any source")
+    print(f"[retention] carried {carried}/{len(eligible)} eligible prior(s) no longer in any source")
 
     deduped = surviving
 

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -1047,16 +1047,25 @@ def main():
         covered_keys.update(e.get("source_ids") or [])
     eligible = load_retained_priors(_load_prev_incidents(), _load_deprecated_ids())
     carried = 0
+    no_keys = 0
     for prior in eligible:
         pid = prior.get("id")
         keys = set(prior.get("cve_ids") or []) | set(prior.get("source_ids") or [])
-        if not keys or (keys & covered_keys) or pid in used_ids:
+        if not keys:
+            # No source_id/cve_id anchor → can't test coverage. This should
+            # never happen for committed output (normalize_entry rejects keyless
+            # rows), so surface it loudly rather than dropping it silently.
+            no_keys += 1
+            continue
+        if (keys & covered_keys) or pid in used_ids:
             continue
         surviving.append(prior)
         covered_keys.update(keys)
         used_ids.add(pid)
         carried += 1
     print(f"[retention] carried {carried}/{len(eligible)} eligible prior(s) no longer in any source")
+    if no_keys:
+        print(f"[retention] WARNING: {no_keys} eligible prior(s) had no source_id/cve_id and could not be retained")
 
     deduped = surviving
 

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -670,9 +670,10 @@ def _load_prev_incidents() -> list[dict]:
     if not prev_path.exists():
         return []
     try:
-        return json.loads(prev_path.read_text(encoding="utf-8")).get("incidents", [])
+        data = json.loads(prev_path.read_text(encoding="utf-8"))
     except (ValueError, OSError):
         return []
+    return data.get("incidents", []) if isinstance(data, dict) else []
 
 
 def _load_deprecated_ids() -> set[str]:
@@ -683,6 +684,8 @@ def _load_deprecated_ids() -> set[str]:
     try:
         deprec = json.loads(DEPRECATIONS_PATH.read_text(encoding="utf-8"))
     except (ValueError, OSError):
+        return set()
+    if not isinstance(deprec, dict):
         return set()
     return {d.get("from") for d in deprec.get("deprecations", []) if d.get("from")}
 

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -664,6 +664,48 @@ def _load_curation_overrides() -> dict[str, dict]:
     return raw.get("overrides", {}) if isinstance(raw, dict) else {}
 
 
+def _load_prev_incidents() -> list[dict]:
+    """Read the previously-published incidents list (empty if none yet)."""
+    prev_path = DATA / "incidents.json"
+    if not prev_path.exists():
+        return []
+    try:
+        return json.loads(prev_path.read_text(encoding="utf-8")).get("incidents", [])
+    except (ValueError, OSError):
+        return []
+
+
+def _load_deprecated_ids() -> set[str]:
+    """Ids that were explicitly retired via merge/dedupe. These must never be
+    resurrected by retention."""
+    if not DEPRECATIONS_PATH.exists():
+        return set()
+    try:
+        deprec = json.loads(DEPRECATIONS_PATH.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return set()
+    return {d.get("from") for d in deprec.get("deprecations", []) if d.get("from")}
+
+
+def load_retained_priors(
+    prev_incidents: list[dict], deprecated_ids: set[str]
+) -> list[dict]:
+    """Select previously-published incidents to carry forward into the build.
+
+    Every prior incident is re-fed as a build input EXCEPT those whose id was
+    explicitly deprecated (merged away). When re-run through dedupe, a prior
+    that still has a live source merges into the fresh entry; a prior with no
+    live source survives on its own — so the dataset never silently drops an
+    incident just because an upstream feed stopped returning it."""
+    out: list[dict] = []
+    for e in prev_incidents:
+        eid = e.get("id")
+        if not eid or eid in deprecated_ids:
+            continue
+        out.append(e)
+    return out
+
+
 def _load_prev_state() -> tuple[
     dict[str, tuple[str, str, dict]],
     dict[str, str],

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -858,6 +858,22 @@ def main():
             all_entries.extend(kept)
             print(f"[{src.name:40s}] {len(raw):4d} raw -> {len(kept):4d} normalized")
 
+    # 2b) Retention backstop: re-feed previously-published incidents (minus
+    #     explicitly deprecated ids) as build inputs. Appended AFTER the ingest
+    #     feeds so a prior that still has a live source merges INTO the fresh
+    #     entry (fresh content wins); a prior with no live source survives.
+    #     This makes the dataset archival — no source dropping an entry can
+    #     silently delete it. See docs/superpowers/specs/2026-06-01-retain-on-drop-design.md
+    prev_incidents = _load_prev_incidents()
+    retained = load_retained_priors(prev_incidents, _load_deprecated_ids())
+    kept_prior = []
+    for r in retained:
+        norm = normalize_entry(r)
+        if norm is not None:
+            kept_prior.append(norm)
+    all_entries.extend(kept_prior)
+    print(f"[retention] re-fed {len(kept_prior)} prior incident(s) as inputs")
+
     # 3) Dedupe
     by_cve: dict[str, dict] = {}
     by_url: dict[str, dict] = {}

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -858,22 +858,6 @@ def main():
             all_entries.extend(kept)
             print(f"[{src.name:40s}] {len(raw):4d} raw -> {len(kept):4d} normalized")
 
-    # 2b) Retention backstop: re-feed previously-published incidents (minus
-    #     explicitly deprecated ids) as build inputs. Appended AFTER the ingest
-    #     feeds so a prior that still has a live source merges INTO the fresh
-    #     entry (fresh content wins); a prior with no live source survives.
-    #     This makes the dataset archival — no source dropping an entry can
-    #     silently delete it. See docs/superpowers/specs/2026-06-01-retain-on-drop-design.md
-    prev_incidents = _load_prev_incidents()
-    retained = load_retained_priors(prev_incidents, _load_deprecated_ids())
-    kept_prior = []
-    for r in retained:
-        norm = normalize_entry(r)
-        if norm is not None:
-            kept_prior.append(norm)
-    all_entries.extend(kept_prior)
-    print(f"[retention] re-fed {len(kept_prior)}/{len(retained)} prior incident(s) as inputs")
-
     # 3) Dedupe
     by_cve: dict[str, dict] = {}
     by_url: dict[str, dict] = {}
@@ -1050,6 +1034,31 @@ def main():
             deprecations_new.append(
                 {"from": old_id, "into": target_id, "reason": "transitive-merge", "date": today_str}
             )
+
+    # 6c) Retention top-up: restore previously-published incidents that the
+    #     fresh build no longer covers (their upstream source dropped them), so
+    #     the dataset is archival and never silently loses an incident. A prior
+    #     is restored only if it was not explicitly deprecated AND none of its
+    #     source_ids / cve_ids are already represented in the fresh build. It is
+    #     carried VERBATIM — keeping its id / added / updated and bypassing
+    #     dedupe — because re-feeding already-built records through the
+    #     raw-ingest dedupe is non-idempotent (it re-canonicalises and can
+    #     oscillate). See docs/superpowers/specs/2026-06-01-retain-on-drop-design.md
+    covered_keys: set[str] = set()
+    for e in surviving:
+        covered_keys.update(e.get("cve_ids") or [])
+        covered_keys.update(e.get("source_ids") or [])
+    carried = 0
+    for prior in load_retained_priors(_load_prev_incidents(), _load_deprecated_ids()):
+        pid = prior.get("id")
+        keys = set(prior.get("cve_ids") or []) | set(prior.get("source_ids") or [])
+        if not keys or (keys & covered_keys) or pid in used_ids:
+            continue
+        surviving.append(prior)
+        covered_keys.update(keys)
+        used_ids.add(pid)
+        carried += 1
+    print(f"[retention] carried forward {carried} prior incident(s) no longer in any source")
 
     deduped = surviving
 

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -872,7 +872,7 @@ def main():
         if norm is not None:
             kept_prior.append(norm)
     all_entries.extend(kept_prior)
-    print(f"[retention] re-fed {len(kept_prior)} prior incident(s) as inputs")
+    print(f"[retention] re-fed {len(kept_prior)}/{len(retained)} prior incident(s) as inputs")
 
     # 3) Dedupe
     by_cve: dict[str, dict] = {}

--- a/tests/test_ingest_oecd_aim.py
+++ b/tests/test_ingest_oecd_aim.py
@@ -1,0 +1,42 @@
+"""Unit tests for the OECD AIM ingester's union-with-existing behaviour."""
+
+from __future__ import annotations
+
+import ingest_oecd_aim as o
+
+
+def _entry(sid, title):
+    return {"source_id": sid, "title": title, "year": 2026,
+            "references": [{"url": "https://oecd.ai/en/incidents/x"}]}
+
+
+def test_union_keeps_aged_out_existing_entries():
+    # Fresh fetch lost OLD-2 (it aged out of the 3000-URL window).
+    fresh = [_entry("OECD-AIM-NEW-1", "new one")]
+    existing = [_entry("OECD-AIM-OLD-2", "old two")]
+    out = o.union_with_existing(fresh, existing)
+    ids = {e["source_id"] for e in out}
+    assert ids == {"OECD-AIM-NEW-1", "OECD-AIM-OLD-2"}
+
+
+def test_union_fresh_wins_on_conflict():
+    fresh = [_entry("OECD-AIM-1", "fresh title")]
+    existing = [_entry("OECD-AIM-1", "stale title")]
+    out = o.union_with_existing(fresh, existing)
+    assert len(out) == 1
+    assert out[0]["title"] == "fresh title"
+
+
+def test_union_output_sorted_by_source_id():
+    fresh = [_entry("OECD-AIM-3", "c"), _entry("OECD-AIM-1", "a")]
+    existing = [_entry("OECD-AIM-2", "b")]
+    out = o.union_with_existing(fresh, existing)
+    assert [e["source_id"] for e in out] == [
+        "OECD-AIM-1", "OECD-AIM-2", "OECD-AIM-3"
+    ]
+
+
+def test_union_drops_entries_without_source_id():
+    fresh = [{"title": "no id", "references": []}]
+    existing = []
+    assert o.union_with_existing(fresh, existing) == []

--- a/tests/test_ingest_oecd_aim.py
+++ b/tests/test_ingest_oecd_aim.py
@@ -38,5 +38,5 @@ def test_union_output_sorted_by_source_id():
 
 def test_union_drops_entries_without_source_id():
     fresh = [{"title": "no id", "references": []}]
-    existing = []
+    existing = [{"title": "also no id"}]
     assert o.union_with_existing(fresh, existing) == []

--- a/tests/test_merge_and_dedupe.py
+++ b/tests/test_merge_and_dedupe.py
@@ -538,3 +538,31 @@ def test_retention_no_duplicate_when_prior_still_covered(tmp_path, monkeypatch):
     d = _json.loads((data / "incidents.json").read_text(encoding="utf-8"))
     assert d["incident_count"] == 1
     assert sum(1 for e in d["incidents"] if "OECD-AIM-A" in e["source_ids"]) == 1
+
+
+def test_retention_carry_is_deterministic_across_days(tmp_path, monkeypatch):
+    """A carried-forward prior must not bump `generated`: rebuilding on a later
+    UTC day with the same inputs is byte-identical (CI drift check stays green)."""
+    data, ingest = _setup_tmp_repo(tmp_path, monkeypatch)
+    monkeypatch.setattr(m, "date", _FrozenDate)
+    monkeypatch.setattr(_FrozenDate, "_pinned", datetime.date(2099, 6, 1))
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-A", "Incident A"),
+         _oecd_entry("OECD-AIM-B", "Incident B")]
+    ), encoding="utf-8")
+    m.main()  # day 1: both present
+
+    # B drops out; it is carried forward on day 2.
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-A", "Incident A")]
+    ), encoding="utf-8")
+    monkeypatch.setattr(_FrozenDate, "_pinned", datetime.date(2099, 6, 2))
+    m.main()
+    day2 = (data / "incidents.json").read_text(encoding="utf-8")
+
+    # Day 3: later calendar day, identical inputs -> must be byte-identical.
+    monkeypatch.setattr(_FrozenDate, "_pinned", datetime.date(2099, 6, 3))
+    m.main()
+    day3 = (data / "incidents.json").read_text(encoding="utf-8")
+
+    assert day2 == day3, "carried-prior rebuild on a later UTC day must be byte-identical"

--- a/tests/test_merge_and_dedupe.py
+++ b/tests/test_merge_and_dedupe.py
@@ -355,3 +355,24 @@ def test_maybe_rewrite_cve_title_skips_blurb_without_cve():
     }
     m.maybe_rewrite_cve_title(entry)
     assert entry["title"].startswith("Some Tool is a")
+
+
+def test_load_retained_priors_excludes_deprecated():
+    prev = [
+        {"id": "INC-00001", "title": "kept"},
+        {"id": "INC-00002", "title": "deprecated"},
+    ]
+    out = m.load_retained_priors(prev, {"INC-00002"})
+    assert [e["id"] for e in out] == ["INC-00001"]
+
+
+def test_load_retained_priors_keeps_all_when_none_deprecated():
+    prev = [{"id": "INC-00001"}, {"id": "INC-00002"}]
+    out = m.load_retained_priors(prev, set())
+    assert len(out) == 2
+
+
+def test_load_retained_priors_skips_entries_without_id():
+    prev = [{"title": "no id"}, {"id": "INC-00003", "title": "ok"}]
+    out = m.load_retained_priors(prev, set())
+    assert [e["id"] for e in out] == ["INC-00003"]

--- a/tests/test_merge_and_dedupe.py
+++ b/tests/test_merge_and_dedupe.py
@@ -498,3 +498,43 @@ def test_build_is_deterministic_across_days(tmp_path, monkeypatch):
     day2 = (data / "incidents.json").read_text(encoding="utf-8")
 
     assert day1 == day2, "rebuild on a later UTC day must be byte-identical"
+
+
+def test_retention_topup_idempotent_after_drop(tmp_path, monkeypatch):
+    """Once a dropped incident is carried forward, further rebuilds with the
+    same inputs must be byte-stable (the top-up must not oscillate)."""
+    data, ingest = _setup_tmp_repo(tmp_path, monkeypatch)
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-A", "Incident A"),
+         _oecd_entry("OECD-AIM-B", "Incident B")]
+    ), encoding="utf-8")
+    m.main()
+
+    # B drops out of the source; it must be carried forward, then stay stable.
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-A", "Incident A")]
+    ), encoding="utf-8")
+    m.main()
+    second = (data / "incidents.json").read_text(encoding="utf-8")
+    m.main()
+    third = (data / "incidents.json").read_text(encoding="utf-8")
+
+    assert second == third, "retention top-up must be idempotent across rebuilds"
+    d = _json.loads(third)
+    assert d["incident_count"] == 2, "A (fresh) + B (carried forward)"
+    srcs = {s for e in d["incidents"] for s in e["source_ids"]}
+    assert {"OECD-AIM-A", "OECD-AIM-B"} <= srcs
+
+
+def test_retention_no_duplicate_when_prior_still_covered(tmp_path, monkeypatch):
+    """A prior whose source still emits it must NOT be carried as a duplicate —
+    the fresh build already represents it."""
+    data, ingest = _setup_tmp_repo(tmp_path, monkeypatch)
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-A", "Incident A")]
+    ), encoding="utf-8")
+    m.main()
+    m.main()  # second build: prior has A and ingest still has A
+    d = _json.loads((data / "incidents.json").read_text(encoding="utf-8"))
+    assert d["incident_count"] == 1
+    assert sum(1 for e in d["incidents"] if "OECD-AIM-A" in e["source_ids"]) == 1

--- a/tests/test_merge_and_dedupe.py
+++ b/tests/test_merge_and_dedupe.py
@@ -376,3 +376,9 @@ def test_load_retained_priors_skips_entries_without_id():
     prev = [{"title": "no id"}, {"id": "INC-00003", "title": "ok"}]
     out = m.load_retained_priors(prev, set())
     assert [e["id"] for e in out] == ["INC-00003"]
+
+
+def test_load_retained_priors_all_deprecated_returns_empty():
+    prev = [{"id": "INC-00001"}, {"id": "INC-00002"}]
+    out = m.load_retained_priors(prev, {"INC-00001", "INC-00002"})
+    assert out == []

--- a/tests/test_merge_and_dedupe.py
+++ b/tests/test_merge_and_dedupe.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import datetime
+import json as _json
+
 import merge_and_dedupe as m
 
 
@@ -384,10 +387,6 @@ def test_load_retained_priors_all_deprecated_returns_empty():
     assert out == []
 
 
-import datetime
-import json as _json
-
-
 class _FrozenDate(datetime.date):
     """date subclass whose today() is pinned, for cross-day determinism tests."""
     _pinned = datetime.date(2099, 6, 1)
@@ -437,6 +436,7 @@ def test_retention_keeps_dropped_incident_with_stable_id(tmp_path, monkeypatch):
         s: e["id"] for e in first["incidents"] for s in e["source_ids"]
     }
     assert {"OECD-AIM-A", "OECD-AIM-B"} <= set(id_by_src)
+    assert len(id_by_src) == 2
     b_id = id_by_src["OECD-AIM-B"]
 
     # Second build: source dropped incident B (aged out / removed upstream).
@@ -476,6 +476,7 @@ def test_deprecated_id_is_not_resurrected(tmp_path, monkeypatch):
     out = _json.loads((data / "incidents.json").read_text(encoding="utf-8"))
     src_ids = {s for e in out["incidents"] for s in e["source_ids"]}
     assert "OECD-AIM-DEAD" not in src_ids, "deprecated entry must not be resurrected"
+    assert "OECD-AIM-LIVE" in src_ids, "live incident must still be present"
 
 
 def test_build_is_deterministic_across_days(tmp_path, monkeypatch):
@@ -487,12 +488,12 @@ def test_build_is_deterministic_across_days(tmp_path, monkeypatch):
 
     # Build on "day 1".
     monkeypatch.setattr(m, "date", _FrozenDate)
-    _FrozenDate._pinned = datetime.date(2099, 6, 1)
+    monkeypatch.setattr(_FrozenDate, "_pinned", datetime.date(2099, 6, 1))
     m.main()
     day1 = (data / "incidents.json").read_text(encoding="utf-8")
 
     # Rebuild on a LATER calendar day with identical inputs.
-    _FrozenDate._pinned = datetime.date(2099, 6, 2)
+    monkeypatch.setattr(_FrozenDate, "_pinned", datetime.date(2099, 6, 2))
     m.main()
     day2 = (data / "incidents.json").read_text(encoding="utf-8")
 

--- a/tests/test_merge_and_dedupe.py
+++ b/tests/test_merge_and_dedupe.py
@@ -382,3 +382,118 @@ def test_load_retained_priors_all_deprecated_returns_empty():
     prev = [{"id": "INC-00001"}, {"id": "INC-00002"}]
     out = m.load_retained_priors(prev, {"INC-00001", "INC-00002"})
     assert out == []
+
+
+import datetime
+import json as _json
+
+
+class _FrozenDate(datetime.date):
+    """date subclass whose today() is pinned, for cross-day determinism tests."""
+    _pinned = datetime.date(2099, 6, 1)
+
+    @classmethod
+    def today(cls):
+        return cls._pinned
+
+
+def _oecd_entry(sid, title):
+    return {
+        "source_id": sid,
+        "title": title,
+        "description": "A description long enough to pass the minimum length filter.",
+        "year": 2026,
+        "date": "2026-04-01",
+        "attack_vector": "deepfake",
+        "severity": "High",
+        "references": [{"url": f"https://oecd.ai/en/incidents/{sid}"}],
+        "tags": ["oecd-aim"],
+    }
+
+
+def _setup_tmp_repo(tmp_path, monkeypatch):
+    data = tmp_path / "data"
+    ingest = tmp_path / "ingest"
+    data.mkdir()
+    ingest.mkdir()
+    monkeypatch.setattr(m, "DATA", data)
+    monkeypatch.setattr(m, "INGEST", ingest)
+    monkeypatch.setattr(m, "DEPRECATIONS_PATH", data / "id_deprecations.json")
+    monkeypatch.setattr(m, "CURATION_OVERRIDES_PATH", data / "curation_overrides.json")
+    return data, ingest
+
+
+def test_retention_keeps_dropped_incident_with_stable_id(tmp_path, monkeypatch):
+    data, ingest = _setup_tmp_repo(tmp_path, monkeypatch)
+
+    # First build: source emits two incidents.
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-A", "Incident A"),
+         _oecd_entry("OECD-AIM-B", "Incident B")]
+    ), encoding="utf-8")
+    m.main()
+    first = _json.loads((data / "incidents.json").read_text(encoding="utf-8"))
+    id_by_src = {
+        s: e["id"] for e in first["incidents"] for s in e["source_ids"]
+    }
+    assert {"OECD-AIM-A", "OECD-AIM-B"} <= set(id_by_src)
+    b_id = id_by_src["OECD-AIM-B"]
+
+    # Second build: source dropped incident B (aged out / removed upstream).
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-A", "Incident A")]
+    ), encoding="utf-8")
+    m.main()
+    second = _json.loads((data / "incidents.json").read_text(encoding="utf-8"))
+    src_ids_second = {s for e in second["incidents"] for s in e["source_ids"]}
+
+    # B is retained, with the SAME id it had before.
+    assert "OECD-AIM-B" in src_ids_second, "dropped incident must be retained"
+    b_id_second = next(
+        e["id"] for e in second["incidents"] if "OECD-AIM-B" in e["source_ids"]
+    )
+    assert b_id_second == b_id
+
+
+def test_deprecated_id_is_not_resurrected(tmp_path, monkeypatch):
+    data, ingest = _setup_tmp_repo(tmp_path, monkeypatch)
+    # Prior output contains INC-09999, which is recorded as deprecated.
+    (data / "incidents.json").write_text(_json.dumps({
+        "incidents": [{
+            **m.normalize_entry(_oecd_entry("OECD-AIM-DEAD", "Dead dup")),
+            "id": "INC-09999", "added": "2026-01-01", "updated": "2026-01-01",
+        }]
+    }), encoding="utf-8")
+    (data / "id_deprecations.json").write_text(_json.dumps({
+        "deprecations": [{"from": "INC-09999", "into": "INC-00001",
+                          "reason": "merged", "date": "2026-01-01"}]
+    }), encoding="utf-8")
+    # Current ingest has one live incident.
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-LIVE", "Live incident")]
+    ), encoding="utf-8")
+    m.main()
+    out = _json.loads((data / "incidents.json").read_text(encoding="utf-8"))
+    src_ids = {s for e in out["incidents"] for s in e["source_ids"]}
+    assert "OECD-AIM-DEAD" not in src_ids, "deprecated entry must not be resurrected"
+
+
+def test_build_is_deterministic_across_days(tmp_path, monkeypatch):
+    data, ingest = _setup_tmp_repo(tmp_path, monkeypatch)
+    (ingest / "src.json").write_text(_json.dumps(
+        [_oecd_entry("OECD-AIM-A", "Incident A"),
+         _oecd_entry("OECD-AIM-B", "Incident B")]
+    ), encoding="utf-8")
+
+    # Build on "day 1".
+    monkeypatch.setattr(m, "date", _FrozenDate)
+    _FrozenDate._pinned = datetime.date(2099, 6, 1)
+    m.main()
+    day1 = (data / "incidents.json").read_text(encoding="utf-8")
+
+    # Rebuild on a LATER calendar day with identical inputs.
+    _FrozenDate._pinned = datetime.date(2099, 6, 2)
+    m.main()
+    day2 = (data / "incidents.json").read_text(encoding="utf-8")
+
+    assert day1 == day2, "rebuild on a later UTC day must be byte-identical"


### PR DESCRIPTION
## Summary

Makes the dataset **archival**: an incident published in `data/incidents.json` is never silently dropped because an upstream source stopped emitting it. It leaves the dataset only via the existing explicit deprecation/merge path.

Two complementary parts:

- **Part A — OECD ingester union** (`scripts/ingest_oecd_aim.py`): the OECD AIM ingester fetches only the 3000-newest sitemap URLs and used to *overwrite* its committed ingest file, so older incidents aged out of the window and vanished. It now **unions** each fetch into the committed file (`union_with_existing`, keyed by `source_id`, fresh wins, sorted), so the corpus only grows.
- **Part B — build-level retention top-up** (`scripts/merge_and_dedupe.py`, step 6c): after the fresh ingest→dedupe build, any previously-published incident whose `source_id`/`cve_id` keys the fresh build no longer covers (and that isn't deprecated) is appended **verbatim**, keeping its id and `added`/`updated`. A general backstop for *any* source, not just OECD.

### Why a post-build top-up (design pivot)

The original design re-fed prior incidents through the dedupe before the build. Implementation testing showed that is **non-idempotent** — the build oscillated (7725 → 7719 → 7725) and **silently dropped 17 CVEs** by exposing a latent core-dedupe bug (entries merged into already-tombstoned records). The top-up bypasses dedupe entirely, so the fresh build is byte-identical to before and retention is purely additive.

### Discovered: a pre-existing core-dedupe bug (deferred)

The dedupe indexes can reference tombstoned entries (`by_title` is never updated on transitive merge; `_reindex` iterates a stale list snapshot), so content can be merged into a dropped entry and lost. Reproducible with a 4-entry fixture and **no retention** — it's latent and dormant on current data. Documented with a minimal repro + proposed fix in `docs/superpowers/specs/2026-06-03-dedup-tombstone-bug.md`; **deferred to its own focused PR** to avoid risking the stable baseline here.

## Validation

- Full rebuild is **byte-identical to the prior committed output** (7725 incidents, `generated` unchanged) — retention carries 0 until a source actually drops something.
- All previously-at-risk CVEs present; **idempotent across 3 consecutive rebuilds**; zero drift over the CI-checked paths.
- `validate.py`: 7725/7725 valid. Test suite: **97 passed** (union helper, retention helpers, e2e retention/deprecation/cross-day-determinism/idempotency, carry-path determinism).

## Test plan

- [ ] CI `validate.yml` (regenerate + drift check) green
- [ ] CodeQL green
- [ ] Review the design pivot + deferred-bug doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)