### PR TITLE
chore(release): bump version to 2.1.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,8 +33,8 @@ abstract: >-
   Framework (AI 100-1), and MITRE ATLAS. Aggregated from AIID, OECD AIM,
   AIAAIC, MITRE ATLAS, AVID, MIT FutureTech AI Risk Navigator, NVD/GHSA/OSV,
   garak, promptfoo, and dozens of researcher blogs and vendor threat reports.
-version: "2.0.0"
-date-released: "2026-05-17"
+version: "2.1.0"
+date-released: "2026-06-03"
 preferred-citation:
   type: dataset
   title: "GenAI & Agentic AI Security Incidents"
@@ -43,6 +43,6 @@ preferred-citation:
       given-names: "Emmanuel"
       alias: "emmanuelgjr"
   year: 2026
-  version: "2.0.0"
+  version: "2.1.0"
   doi: 10.5281/zenodo.20248676
   url: "https://doi.org/10.5281/zenodo.20248676"

--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -3,7 +3,7 @@
 Single source of truth for GenAI and agentic AI security incidents.
 Each entry is mapped to **OWASP LLM Top 10 (2025)**, **OWASP Agentic Top 10 (ASI)**, **NIST AI RMF**, and **MITRE ATLAS**.
 
-- **Version:** 2.0.0
+- **Version:** 2.1.0
 - **Generated:** 2026-05-30
 - **Total incidents:** **7,725**
 - **Date range:** 1983 – 2026

--- a/data/incidents.json
+++ b/data/incidents.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "generated": "2026-05-30",
   "description": "Single source of truth for GenAI and agentic AI security incidents. Each entry is mapped to OWASP LLM Top 10 (2025), OWASP Agentic ASI Top 10, NIST AI RMF (AI 100-1), and MITRE ATLAS where applicable.",
   "schema": "schema/incident.schema.json",

--- a/data/incidents.min.json
+++ b/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "generated": "2026-05-30",
   "incident_count": 7725,
   "incidents": [

--- a/docs/data/incidents.min.json
+++ b/docs/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "generated": "2026-05-30",
   "incident_count": 7725,
   "incidents": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genai-incidents"
-version = "2.0.0"
+version = "2.1.0"
 description = "Curated dataset of GenAI & agentic-AI security incidents mapped to OWASP LLM Top 10, OWASP Agentic Top 10, NIST AI RMF, and MITRE ATLAS."
 readme = "README.md"
 license = "MIT"

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -1117,7 +1117,7 @@ def main():
 
     # 9) Write outputs
     out = {
-        "version": "2.0.0",
+        "version": "2.1.0",
         "generated": generated,
         "description": (
             "Single source of truth for GenAI and agentic AI security incidents. "

--- a/src/genai_incidents/data/incidents.min.json
+++ b/src/genai_incidents/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "generated": "2026-05-30",
   "incident_count": 7725,
   "incidents": [


### PR DESCRIPTION
## Summary
Version bump 2.0.0 → **2.1.0** in preparation for the v2.1.0 GitHub Release.

- `pyproject.toml`, `CITATION.cff` (+ `date-released: 2026-06-03`), and the data `version` string (`scripts/merge_and_dedupe.py`) bumped.
- Outputs regenerated. The **only** data change is the `version` field — the `generated` date is preserved because no incident content changed (deterministic build).

## Why 2.1.0
Backward-compatible feature work merged since 2.0.0: retain-on-drop, STIX + Hugging Face exporters, MITRE ATLAS tactics, CVE CWE/CVSS capture, red-team benchmark catalogue, and quality-tier curation passes.

## After merge
Tag/create Release **v2.1.0**, which auto-triggers PyPI (clean new version) and the Hugging Face publish.

## Test plan
- [ ] `validate.yml` (regenerate + drift) green
- [ ] CodeQL green

🤖 Generated with [Claude Code](https://claude.com/claude-code)