### PR TITLE
docs(hf): enrich dataset card for discoverability + HF badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 [![Validate dataset](https://github.com/emmanuelgjr/genai_incidents/actions/workflows/validate.yml/badge.svg)](https://github.com/emmanuelgjr/genai_incidents/actions/workflows/validate.yml)
 [![PyPI version](https://img.shields.io/pypi/v/genai-incidents?logo=pypi&logoColor=white&label=pypi)](https://pypi.org/project/genai-incidents/)
 [![Python versions](https://img.shields.io/pypi/pyversions/genai-incidents?logo=python&logoColor=white)](https://pypi.org/project/genai-incidents/)
+[![Hugging Face dataset](https://img.shields.io/badge/%F0%9F%A4%97%20Hugging%20Face-dataset-yellow)](https://huggingface.co/datasets/emmanuelgjr/genai-incidents)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20248676.svg)](https://doi.org/10.5281/zenodo.20248676)
 [![License: MIT (code)](https://img.shields.io/badge/code-MIT-blue.svg)](LICENSE)
 [![License: CC-BY-4.0 (data)](https://img.shields.io/badge/data-CC--BY--4.0-lightgrey.svg)](LICENSE-DATA)
 
 - 🔎 **Searchable site:** <https://emmanuelgjr.github.io/genai_incidents/>
 - 📦 **Python:** `pip install genai-incidents`
-- 🤗 **Hugging Face:** `load_dataset("emmanuelgjr/genai-incidents")` — built with `make huggingface`
+- 🤗 **Hugging Face:** [`emmanuelgjr/genai-incidents`](https://huggingface.co/datasets/emmanuelgjr/genai-incidents) — `load_dataset("emmanuelgjr/genai-incidents")` (built with `make huggingface`)
 - 🛰️ **STIX 2.1 bundle** (for OpenCTI / MISP / TAXII): <https://emmanuelgjr.github.io/genai_incidents/data/incidents.stix.json> — incidents as `x-genai-incident` SDOs linked to MITRE ATLAS `attack-pattern`s and CVE `vulnerability`s. Build locally with `make stix`.
 - 📖 **Field reference:** [`docs/DATA_DICTIONARY.md`](docs/DATA_DICTIONARY.md) · **Provenance & limitations:** [`docs/DATASHEET.md`](docs/DATASHEET.md)
 - 🪪 **DOI:** [`10.5281/zenodo.20248676`](https://doi.org/10.5281/zenodo.20248676) — see [`CITATION.cff`](CITATION.cff)

--- a/scripts/export_huggingface.py
+++ b/scripts/export_huggingface.py
@@ -32,14 +32,20 @@ language:
 pretty_name: GenAI & Agentic AI Security Incidents
 tags:
   - security
+  - cybersecurity
   - ai-safety
+  - ai-security
   - llm
+  - agentic-ai
   - incidents
+  - threat-intelligence
+  - prompt-injection
   - owasp
   - mitre-atlas
   - nist-ai-rmf
 task_categories:
   - text-classification
+  - text-retrieval
 size_categories:
   - 1K<n<10K
 configs:
@@ -49,23 +55,65 @@ configs:
 
 # GenAI & Agentic AI Security Incidents
 
-{count} real-world and research GenAI / agentic-AI security incidents, each mapped to
-**OWASP LLM Top 10 (2025)**, **OWASP Agentic (ASI) Top 10**, **NIST AI RMF**, and
-**MITRE ATLAS** (techniques + tactics). Dataset version `{version}`.
+**{count} real-world and research incidents** involving generative-AI and agentic-AI
+systems — prompt injection, jailbreaks, data exfiltration, deepfakes, model and
+supply-chain compromise, agent hijacking, and AI-enabled harms — each mapped to four
+industry frameworks. Dataset version `{version}`.
+
+Every incident is tagged with:
+
+- **OWASP Top 10 for LLM Applications (2025)** — `LLM01`–`LLM10`
+- **OWASP Agentic Top 10 (ASI)** — `ASI01`–`ASI10`
+- **NIST AI RMF (AI 100-1)** — `GOVERN` / `MAP` / `MEASURE` / `MANAGE`
+- **MITRE ATLAS** — techniques (`AML.T00xx`) and tactics (`AML.TA00xx`)
+
+## Quickstart
 
 ```python
 from datasets import load_dataset
 ds = load_dataset("{repo}", split="train")
-ds = ds.filter(lambda r: "LLM01" in (r["owasp_llm"] or []))   # prompt-injection incidents
+
+# prompt-injection incidents
+ds.filter(lambda r: "LLM01" in (r["owasp_llm"] or []))
+
+# only maintainer-reviewed entries
+ds.filter(lambda r: r["quality_tier"] in ("reviewed", "curated"))
 ```
 
-- Code: <https://github.com/emmanuelgjr/genai_incidents>
-- Schema & field reference: [`docs/DATA_DICTIONARY.md`](https://github.com/emmanuelgjr/genai_incidents/blob/main/docs/DATA_DICTIONARY.md)
-- Provenance, scope & limitations: [`docs/DATASHEET.md`](https://github.com/emmanuelgjr/genai_incidents/blob/main/docs/DATASHEET.md)
-- Citation: see [`CITATION.cff`](https://github.com/emmanuelgjr/genai_incidents/blob/main/CITATION.cff) · DOI [10.5281/zenodo.20248676](https://doi.org/10.5281/zenodo.20248676)
+## What's inside
 
-**Licence:** data CC-BY-4.0, code MIT. Each entry carries a `quality_tier`
-(`curated` / `reviewed` / `auto`) so consumers can filter by vetting level.
+Key fields per record (full reference in the data dictionary):
+
+- `id`, `title`, `description`, `date`, `year`, `severity`
+- `attack_vector` — normalised exploit/harm class (e.g. `prompt-injection`, `deepfake`, `rce`)
+- `owasp_llm`, `owasp_asi`, `nist_ai_rmf`, `mitre_atlas`, `mitre_atlas_tactics` — framework mappings
+- `cve_ids`, `cwe_ids`, `cvss_score` — where applicable
+- `references` — source URLs · `source_ids` — upstream provenance
+- `quality_tier` — `curated` / `reviewed` / `auto` (filter by vetting level)
+- `corpus` — `security` or `ai-harm`
+
+## Sources & provenance
+
+Aggregated and de-duplicated from AIID, OECD AI Incidents Monitor, AIAAIC, MITRE ATLAS,
+AVID, MIT FutureTech AI Risk Repository, NVD / GitHub Security Advisories / OSV, garak,
+promptfoo, red-team benchmark catalogues, and researcher blogs / vendor threat reports.
+
+## Intended uses & limitations
+
+Built for security research, red-team scenario design, taxonomy / benchmark work, and
+trend analysis. It is **not** an exhaustive census: coverage skews toward
+English-language, publicly-reported events, and `auto`-tier rows are bulk-ingested
+without individual review — filter on `quality_tier` for higher-confidence subsets. See
+the datasheet for full scope, collection method, and limitations.
+
+## Links
+
+- **Code & issues:** <https://github.com/emmanuelgjr/genai_incidents>
+- **Field reference:** [`docs/DATA_DICTIONARY.md`](https://github.com/emmanuelgjr/genai_incidents/blob/main/docs/DATA_DICTIONARY.md)
+- **Provenance, scope & limitations:** [`docs/DATASHEET.md`](https://github.com/emmanuelgjr/genai_incidents/blob/main/docs/DATASHEET.md)
+- **Citation:** [`CITATION.cff`](https://github.com/emmanuelgjr/genai_incidents/blob/main/CITATION.cff) · DOI [10.5281/zenodo.20248676](https://doi.org/10.5281/zenodo.20248676)
+
+**Licence:** data **CC-BY-4.0**, code MIT.
 """
 
 


### PR DESCRIPTION
## Summary
Improves Hugging Face discoverability and cross-linking.

- **HF dataset card** (`scripts/export_huggingface.py`): richer front-matter tags (`cybersecurity`, `ai-security`, `agentic-ai`, `threat-intelligence`, `prompt-injection`; adds `text-retrieval` task) and a fuller body — what's-inside field list, quickstart with a `quality_tier` filter, sources/provenance, and intended-uses/limitations. Better search ranking + a page that converts visitors.
- **README**: clickable 🤗 Hugging Face badge in the badge row + the HF bullet is now a direct link to the dataset page.

Card template still satisfies the exporter test (front matter, `cc-by-4.0`, `configs:` + `incidents.jsonl`); rendered locally with all fields substituted.

## After merge
Re-run **Publish to Hugging Face** to push the enriched card to the Hub.

## Test plan
- [ ] `validate.yml` green · CodeQL green
- [ ] `test_export_huggingface.py` passes (card front matter intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)