### PR TITLE
fix(hf): skip create_repo when dataset exists (avoid 429 on republish)

### DIFF
--- a/scripts/export_huggingface.py
+++ b/scripts/export_huggingface.py
@@ -148,7 +148,12 @@ def main() -> None:
             sys.exit(1)
         from huggingface_hub import HfApi
         api = HfApi(token=token)
-        api.create_repo(args.repo, repo_type="dataset", exist_ok=True)
+        # Only create the repo if it doesn't exist yet. Calling create_repo on
+        # every publish (even with exist_ok=True) hits HF's repo-create rate
+        # limit and 429s on repeated/automated runs; the lightweight existence
+        # check avoids that. upload_folder uses separate, higher limits.
+        if not api.repo_exists(args.repo, repo_type="dataset"):
+            api.create_repo(args.repo, repo_type="dataset")
         api.upload_folder(folder_path=str(OUT), repo_id=args.repo, repo_type="dataset")
         print(f"[hf] pushed to https://huggingface.co/datasets/{args.repo}")
 


### PR DESCRIPTION
## Summary
The Hugging Face publish failed with `429 Too Many Requests` on `api/repos/create` after several publishes in quick succession. `create_repo(..., exist_ok=True)` was called on every run and counts against HF's repo-create rate limit.

Guard it behind a lightweight `repo_exists()` check so the create call only happens on a genuine first publish. `upload_folder` (the operation that matters) uses separate, higher limits, so publishes are now reliable.

## Test plan
- [ ] `test_export_huggingface.py` passes (build path unchanged)
- [ ] After merge, re-run **Publish to Hugging Face** → succeeds and pushes the enriched card

🤖 Generated with [Claude Code](https://claude.com/claude-code)