### PR TITLE
fix(site): keep OWASP chart labels in-box + refine chart palette

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -381,7 +381,10 @@ function renderBarChart(containerId, items, onClick, opts = {}) {
   const bars = items.map((it, i) => {
     const y = M_TOP + i * ROW_H + 4;
     const bw = (it.value / maxV) * chartW;
-    const labelTrunc = it.label.length > 32 ? it.label.slice(0, 31) + '…' : it.label;
+    // Truncate to what actually fits the label gutter (M_LEFT) at the mono
+    // label size (~6.8px/char), so labels never overflow the chart box.
+    const maxChars = Math.max(6, Math.floor((M_LEFT - 12) / 6.8));
+    const labelTrunc = it.label.length > maxChars ? it.label.slice(0, maxChars - 1) + '…' : it.label;
     const color = it.color || 'var(--bar)';
     const filterPayload = JSON.stringify(it.filter || null).replace(/"/g, '&quot;');
     return `
@@ -547,7 +550,7 @@ function renderAllCharts() {
   const llmItems = Object.keys(LLM_NAMES).map(k => ({
     label: `${k} · ${LLM_NAMES[k]}`, value: llmCounts[k] || 0, filter: { llm: k },
   })).sort((a,b) => b.value - a.value);
-  renderBarChart(CHART_ID.llm, llmItems, applyChartFilter, { rowH: 24 });
+  renderBarChart(CHART_ID.llm, llmItems, applyChartFilter, { rowH: 24, leftPad: 250 });
 
   // OWASP ASI bar chart
   const asiCounts = {};
@@ -556,7 +559,7 @@ function renderAllCharts() {
   const asiItems = Object.keys(ASI_NAMES).map(k => ({
     label: `${k} · ${ASI_NAMES[k]}`, value: asiCounts[k] || 0, filter: { asi: k },
   })).sort((a,b) => b.value - a.value);
-  renderBarChart(CHART_ID.asi, asiItems, applyChartFilter, { rowH: 24 });
+  renderBarChart(CHART_ID.asi, asiItems, applyChartFilter, { rowH: 24, leftPad: 250 });
 
   // Top attack vectors — fewer rows on narrow viewports
   const vecCounts = {};

--- a/docs/style.css
+++ b/docs/style.css
@@ -28,12 +28,14 @@
   /* severity ramp — also the chart palette */
   --critical:  #ff4d63;
   --high:      #ff8a3d;
-  --medium:    #ffd23f;
+  --medium:    #f5c542;   /* calmer gold — clearly distinct from the amber accent */
   --low:       #46d6b6;
   --info:      #6f7c91;
 
-  /* neutral category bar (year / vectors / vendors charts) */
-  --bar:       #41506a;
+  /* neutral category bar (year / vectors / vendors charts) — cool steel so
+     "how many" charts read as data, distinct from the warm severity ramp
+     and the amber chrome. */
+  --bar:       #6f93b8;
 
   --radius:    4px;
   --mono: "IBM Plex Mono", ui-monospace, "SFMono-Regular", Menlo, monospace;
@@ -517,7 +519,7 @@ td.cves { font-family: var(--mono); font-size: 0.76rem; color: var(--muted); whi
 }
 .sev-badge.sev-Critical { color: var(--critical); background: rgba(255, 77, 99, 0.12); }
 .sev-badge.sev-High     { color: var(--high);     background: rgba(255, 138, 61, 0.12); }
-.sev-badge.sev-Medium   { color: var(--medium);   background: rgba(255, 210, 63, 0.12); }
+.sev-badge.sev-Medium   { color: var(--medium);   background: rgba(245, 197, 66, 0.12); }
 .sev-badge.sev-Low      { color: var(--low);      background: rgba(70, 214, 182, 0.12); }
 .sev-badge.sev-Info     { color: var(--info);     background: rgba(111, 124, 145, 0.14); }
 


### PR DESCRIPTION
Follow-up polish to the redesigned Pages site (#23).

## Fixes
- **OWASP LLM / ASI chart labels overflowed the chart box.** The horizontal bar renderer truncated row labels at a fixed 31 chars in a 170px gutter, so labels like `ASI03 · Identity & Privilege Abuse` spilled left out of the SVG. Now: truncation is derived from the label gutter width, and the OWASP charts get a wider 250px gutter. Long vendor labels benefit from the same change. **Verified headless: 0 row-label overflows across all four bar charts, 0 page errors.**

## Palette refinement
- Neutral **volume bars** (`--bar`) lifted from a muddy dark slate to a clean **steel-blue**, so "how many" charts (incidents/year, attack vectors, vendors) read as cool data — distinct from the warm severity ramp and the amber chrome.
- **Medium** severity nudged to a calmer gold so it no longer collides visually with the amber accent.

Presentation/renderer only — app.js DOM contract and the deterministic build are untouched; no drift-checked paths changed.

## Test plan
- [ ] validate (drift) + CodeQL green
- [ ] After deploy, confirm OWASP chart labels render fully inside their cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)