### PR TITLE
ci: least-privilege permissions, SHA-pin PyPI publish, test on 3.13

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build sdist + wheel
         run: python -m build
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           # Uses PyPI trusted-publishing (OIDC). Configure once in PyPI:
           # Account settings -> Publishing -> Add a new pending publisher.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,15 +5,21 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
 
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
 
       - name: Install dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Security",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]


### PR DESCRIPTION
Three small CI-hygiene fixes from a repo review:

- **validate.yml**: add an explicit `permissions: contents: read` block — every other workflow declares least-privilege; this one inherited the repo default.
- **validate.yml**: run the validate job on a **3.12 / 3.13 matrix**, so the deterministic-build drift check now also proves the pipeline reproduces byte-identically on Python 3.13.
- **publish.yml**: pin `pypa/gh-action-pypi-publish` to the **v1.14.0 commit SHA** instead of the mutable `release/v1` branch — supply-chain hardening for the action that publishes the package (create-pull-request is already SHA-pinned; this brings publish in line).
- **pyproject.toml**: add the `3.13` classifier (`requires-python >=3.10` already allows it; now CI actually tests it).

Verified locally: full build pipeline reproduces with zero drift; 97 unit tests pass.