### PR TITLE
fix(pipeline): stamp dates from the UTC calendar, not the local clock

### DIFF
--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -14,8 +14,15 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from datetime import date
+from datetime import date, datetime, timezone
 from collections import defaultdict
+
+
+def utc_today() -> date:
+    """Calendar date in UTC. CI builds run in UTC; a contributor whose local
+    clock lags UTC must stamp the same dates as a same-UTC-day CI build, or
+    the deterministic drift check flaps."""
+    return datetime.now(timezone.utc).date()
 
 ROOT = Path(__file__).resolve().parents[1]
 INGEST = ROOT / "ingest"
@@ -804,7 +811,7 @@ def _content_snapshot(entry: dict) -> dict:
 def _apply_history(entry: dict, prev_ts: dict[str, tuple[str, str, dict]]) -> None:
     """Look up the entry's previous timestamps by any matching CVE/source ID
     and apply them. Bump `updated` only when content actually changed."""
-    today = str(date.today())
+    today = str(utc_today())
     keys = list(entry.get("cve_ids") or []) + list(entry.get("source_ids") or [])
     prev = next((prev_ts[k] for k in keys if k in prev_ts), None)
     if prev is None:
@@ -994,7 +1001,7 @@ def main():
     #      as tombstones so their old IDs can be recorded for citation
     #      resolution below.
     surviving, tombstones = dedupe_entries(all_entries)
-    today_str = str(date.today())
+    today_str = str(utc_today())
 
     # 4b) Finalize attack_vector (normalize fragments + reclassify "other")
     #     BEFORE stamping history. attack_vector is part of the content
@@ -1129,7 +1136,7 @@ def main():
     # 7) Compute `generated`: today only if anything actually changed since
     #    the previous output; otherwise preserve the previous timestamp so
     #    CI drift checks don't flap on every daily re-run.
-    today = str(date.today())
+    today = str(utc_today())
     any_change = any((e.get("updated") or "") == today for e in deduped)
     prev_generated = ""
     try:
@@ -1283,7 +1290,7 @@ def merge_into(target: dict, src: dict):
     # Prefer the more specific / more plausible date.
     # Specificity: YYYY-MM-DD > YYYY-MM > YYYY. A future-year date should be
     # overridden by a same-or-earlier date from any other source.
-    current_year = date.today().year
+    current_year = utc_today().year
     src_date = (src.get("date") or "").strip()
     tgt_date = (target.get("date") or "").strip()
 

--- a/scripts/parse_existing.py
+++ b/scripts/parse_existing.py
@@ -22,7 +22,14 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from datetime import date
+from datetime import date, datetime, timezone
+
+
+def utc_today() -> date:
+    """Calendar date in UTC. CI builds run in UTC; a contributor whose local
+    clock lags UTC must stamp the same dates as a same-UTC-day CI build, or
+    the deterministic drift check flaps."""
+    return datetime.now(timezone.utc).date()
 
 ROOT = Path(__file__).resolve().parents[1]
 LEGACY = ROOT / "legacy"
@@ -184,8 +191,8 @@ def parse_json_source(path: Path, start_id: int) -> tuple[list[dict], int]:
                 for r in entry.get("references", []) if r.get("url")
             ],
             "tags": entry.get("tags", []),
-            "added": str(date.today()),
-            "updated": str(date.today()),
+            "added": str(utc_today()),
+            "updated": str(utc_today()),
         }
         # Year defaults
         if not new_entry["year"]:
@@ -357,8 +364,8 @@ def parse_md_table(path: Path, start_id: int) -> tuple[list[dict], int]:
             "mitre_atlas": atlas,
             "references": refs,
             "tags": [],
-            "added": str(date.today()),
-            "updated": str(date.today()),
+            "added": str(utc_today()),
+            "updated": str(utc_today()),
         }
         out.append(entry)
         next_id += 1
@@ -387,7 +394,7 @@ def main():
         json.dumps(
             {
                 "version": "1.0.0",
-                "generated": str(date.today()),
+                "generated": str(utc_today()),
                 "source": "legacy consolidation",
                 "incidents": all_entries,
             },

--- a/scripts/render_markdown.py
+++ b/scripts/render_markdown.py
@@ -19,8 +19,15 @@ from __future__ import annotations
 import json
 import re
 from collections import Counter, defaultdict
-from datetime import date
+from datetime import date, datetime, timezone
 from pathlib import Path
+
+
+def utc_today() -> date:
+    """Calendar date in UTC. CI builds run in UTC; a contributor whose local
+    clock lags UTC must stamp the same dates as a same-UTC-day CI build, or
+    the deterministic drift check flaps."""
+    return datetime.now(timezone.utc).date()
 
 ROOT = Path(__file__).resolve().parents[1]
 DATA = ROOT / "data"
@@ -471,7 +478,7 @@ def render():
     )
     lines.append("")
     lines.append(f"- **Version:** {raw.get('version','1.0.0')}")
-    lines.append(f"- **Generated:** {raw.get('generated', str(date.today()))}")
+    lines.append(f"- **Generated:** {raw.get('generated', str(utc_today()))}")
     lines.append(f"- **Total incidents:** **{len(entries):,}**")
     if year_counts:
         latest = max(year_counts)


### PR DESCRIPTION
`date.today()` resolves in the local timezone, but the drift-checked outputs are built in UTC on CI. A contributor whose local clock lags UTC (e.g. the Americas) building on the same UTC day as a CI-built refresh stamps `added`/`updated`/`generated` dates one day behind — PR #32's first CI run failed exactly this way (local 2026-06-09 vs CI 2026-06-10, drift on the `generated` header).

Adds a `utc_today()` helper to `merge_and_dedupe.py`, `parse_existing.py`, and `render_markdown.py` and uses it at every date-stamp site.

Verified: 100 tests pass; full rebuild on a UTC-lagging local machine is now drift-clean against main; rebuild with `datetime.now` faked to 2026-07-15 UTC is byte-identical (cross-day stability intact).