### PR TITLE
feat(ci): dispatchable CVE enrichment workflow; fix GHSA decoding on Windows

### DIFF
--- a/.github/workflows/cve-enrich.yml
+++ b/.github/workflows/cve-enrich.yml
@@ -1,0 +1,94 @@
+name: CVE enrichment
+
+# Manually-dispatched re-pull of AI/ML-related CVEs (NVD + GHSA + OSV) to
+# refresh cve-derived fields (cwe_ids, cvss_vector, cvss_score, new CVEs).
+# Runs on CI rather than a maintainer laptop for two practical reasons:
+#  - the public-rate NVD pull takes a long time (set the NVD_API_KEY repo
+#    secret to use NVD's 50 req/30s tier — ~10x faster);
+#  - the output JSON embeds verbatim advisory text whose IoC strings can
+#    trip desktop antivirus content signatures (observed: Windows Defender
+#    quarantining ingest/cve_nvd_expanded.json as a false positive).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: cve-enrich
+  cancel-in-progress: false
+
+jobs:
+  enrich:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Re-pull AI/ML CVEs (NVD + GHSA + OSV)
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
+        run: python scripts/ingest_cve_nvd_expanded.py
+
+      - name: Re-merge + render + validate
+        run: |
+          python scripts/parse_existing.py
+          python scripts/merge_and_dedupe.py
+          python scripts/render_markdown.py
+          python scripts/validate.py
+
+      # Same hard gate as the weekly refresh: a regression in the enriched
+      # data or generated outputs blocks the PR instead of shipping it.
+      - name: Unit tests
+        run: pytest tests -q
+
+      - name: Show summary
+        run: |
+          echo "::group::Diff stats"
+          git diff --stat || true
+          echo "::endgroup::"
+          echo "::group::Counts"
+          python - <<'EOF'
+          import json
+          d = json.load(open("data/incidents.json"))
+          inc = d["incidents"]
+          cve = [e for e in inc if e.get("cve_ids")]
+          print("total:", d["incident_count"], "| generated:", d["generated"])
+          print("cve-bearing:", len(cve))
+          print("with cwe_ids:", sum(1 for e in cve if e.get("cwe_ids")))
+          print("with cvss_vector:", sum(1 for e in cve if e.get("cvss_vector")))
+          EOF
+          echo "::endgroup::"
+
+      - name: Open / update enrichment PR
+        # Pinned to a full commit SHA (v7) for supply-chain safety; bump
+        # deliberately rather than tracking a mutable tag.
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          commit-message: "feat(data): refresh CVE enrichment (cwe_ids, cvss_vector, new CVEs)"
+          branch: cve-enrich/data
+          base: main
+          delete-branch: true
+          title: "CVE enrichment refresh"
+          labels: data-refresh, automated
+          body: |
+            Automated re-pull of AI/ML-related CVEs from NVD + GitHub Security
+            Advisories + OSV.dev, refreshing `cwe_ids`, `cvss_vector`,
+            `cvss_score`, and any newly-published CVEs.
+
+            On each run this branch is recreated from the current `main`, so
+            the diff is always relative to the latest `main` *at run time*.
+            **Merge promptly** — if commits land on `main` after this PR
+            opens, close it and re-run the workflow instead of merging.
+
+            Schema validation and the full unit-test suite ran green in this
+            workflow before the PR was opened.

--- a/scripts/ingest_cve_nvd_expanded.py
+++ b/scripts/ingest_cve_nvd_expanded.py
@@ -572,7 +572,11 @@ def fetch_ghsa(max_pages: int = 60) -> list[dict]:
         after_arg = ["-f", f"after={cursor}"] if cursor else []
         cmd = ["gh", "api", "graphql", "-f", f"query={GHSA_QUERY}", *after_arg]
         try:
-            out = subprocess.run(cmd, capture_output=True, text=True, timeout=90)
+            # encoding= matters: text=True alone decodes with the locale
+            # codec (cp1252 on Windows) and UnicodeDecodeErrors on UTF-8
+            # advisory text, silently yielding 0 advisories.
+            out = subprocess.run(cmd, capture_output=True, text=True,
+                                 encoding="utf-8", errors="replace", timeout=90)
         except FileNotFoundError:
             print("  [warn] gh CLI not available; skipping GHSA", flush=True)
             return []


### PR DESCRIPTION
Two pieces that unblock the long-pending CVE field enrichment (`cwe_ids`/`cvss_vector` are 0/1,654 on CVE-bearing incidents):

**1. New `CVE enrichment` workflow** (manual dispatch) — re-pulls AI/ML CVEs from NVD + GHSA + OSV with the post-#17 ingester, rebuilds + validates + tests, and opens a data PR with the same gates and SHA-pinned `create-pull-request` as the weekly refresh. Why CI and not a laptop:
- the public-rate NVD pull takes a long while locally; the workflow reads the **`NVD_API_KEY` secret** (free key) for NVD's 50 req/30s tier via #30,
- the output JSON embeds verbatim advisory text whose IoC strings **trip desktop antivirus** — confirmed locally: Windows Defender repeatedly quarantined `ingest/cve_nvd_expanded.json` as `Trojan:Python/ShaiWorm.DZ!MTB` (false positive on threat-intel content describing the Shai-Hulud npm worm).

**2. GHSA decoding fix** — `subprocess.run(..., text=True)` decodes with the locale codec (cp1252 on Windows), which `UnicodeDecodeError`s on UTF-8 advisory text and silently yields **0 GHSA advisories**. Forcing `encoding='utf-8', errors='replace'` fixed it (verified locally: 0 → 6,000 advisories → 1,631 GHSA-only entries).