### PR TITLE
ci: bump create-pull-request to v8.1.1 (Node 24)

### DIFF
--- a/.github/workflows/auto-refresh.yml
+++ b/.github/workflows/auto-refresh.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Open / update refresh PR
         # Pinned to a full commit SHA (v7) for supply-chain safety; bump
         # deliberately rather than tracking a mutable tag.
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "chore(data): weekly auto-refresh"
           branch: auto-refresh/data

--- a/.github/workflows/cve-enrich.yml
+++ b/.github/workflows/cve-enrich.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Open / update enrichment PR
         # Pinned to a full commit SHA (v7) for supply-chain safety; bump
         # deliberately rather than tracking a mutable tag.
-        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           commit-message: "feat(data): refresh CVE enrichment (cwe_ids, cvss_vector, new CVEs)"
           branch: cve-enrich/data


### PR DESCRIPTION
Both data workflows (`auto-refresh.yml`, `cve-enrich.yml`) pin `peter-evans/create-pull-request` at a v7 commit that runs on Node 20, which GitHub force-migrates to Node 24 on **June 16, 2026** (runs currently annotate the deprecation warning). Bumped to the **v8.1.1** release commit SHA — same pin-by-SHA supply-chain policy. v8's breaking change is only the Node 24 runtime requirement; inputs used here are unchanged.