### PR TITLE
validate: enforce CVE/source uniqueness + deprecation integrity (CI gate)

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -18,6 +18,52 @@ except ImportError:
     sys.exit(2)
 
 
+def check_integrity(data: dict, deprecations: list[dict] | None = None) -> list[str]:
+    """Cross-entry invariants the JSON schema can't express. Returns a list
+    of violation messages (empty == clean).
+
+    1+2. No CVE id or source_id may be held by two live entries. Dedupe
+         guarantees each maps to exactly one incident; a duplicate means
+         content was silently split across records — the failure mode of the
+         2026-06 dedupe tombstone bug. This is the machine check for the
+         audit done by hand when that bug was fixed.
+    3.   id_deprecations referential integrity: every deprecated `from` id
+         must resolve through its `into` chain to a live entry, and no
+         deprecated id may still be live (an old citation must land
+         somewhere real and unambiguous).
+    """
+    problems: list[str] = []
+    incidents = data["incidents"]
+    live_ids = {e["id"] for e in incidents}
+
+    for field in ("cve_ids", "source_ids"):
+        holders: dict[str, str] = {}
+        for e in incidents:
+            for key in e.get(field) or []:
+                if key in holders:
+                    problems.append(
+                        f"{field} {key!r} held by both {holders[key]} and {e['id']}"
+                    )
+                else:
+                    holders[key] = e["id"]
+
+    if deprecations is not None:
+        into_map = {d.get("from"): d.get("into") for d in deprecations}
+        for frm, into in into_map.items():
+            if frm in live_ids:
+                problems.append(f"deprecated id {frm} is still a live entry")
+            seen: set[str] = set()
+            cur = into
+            while cur in into_map and cur not in live_ids and cur not in seen:
+                seen.add(cur)
+                cur = into_map[cur]
+            if cur not in live_ids:
+                problems.append(
+                    f"deprecation {frm} -> {into} does not resolve to a live entry"
+                )
+    return problems
+
+
 def main():
     schema = json.loads((ROOT / "schema" / "incident.schema.json").read_text(encoding="utf-8"))
     data = json.loads((ROOT / "data" / "incidents.json").read_text(encoding="utf-8"))
@@ -35,7 +81,22 @@ def main():
                     print(f"  - {path}: {e.message}")
     total = len(data["incidents"])
     print(f"\n{total - errors}/{total} entries valid; {errors} with errors.")
-    sys.exit(1 if errors else 0)
+
+    dep_path = ROOT / "data" / "id_deprecations.json"
+    deprecations: list[dict] = []
+    if dep_path.exists():
+        deprecations = json.loads(dep_path.read_text(encoding="utf-8")).get(
+            "deprecations", []
+        )
+    problems = check_integrity(data, deprecations)
+    if problems:
+        print(f"\n{len(problems)} integrity violation(s):")
+        for p in problems[:20]:
+            print(f"  - {p}")
+    else:
+        print("integrity: no duplicate CVE/source keys; all deprecations resolve.")
+
+    sys.exit(1 if (errors or problems) else 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,65 @@
+"""Tests for the cross-entry integrity invariants in validate.py."""
+
+from __future__ import annotations
+
+import validate as v
+
+
+def _data(*incidents):
+    return {"incidents": list(incidents)}
+
+
+def test_integrity_clean():
+    data = _data(
+        {"id": "INC-1", "cve_ids": ["CVE-1"], "source_ids": ["S-1"]},
+        {"id": "INC-2", "cve_ids": ["CVE-2"], "source_ids": ["S-2"]},
+    )
+    assert v.check_integrity(data, []) == []
+
+
+def test_integrity_duplicate_cve_flagged():
+    data = _data(
+        {"id": "INC-1", "cve_ids": ["CVE-1"], "source_ids": ["S-1"]},
+        {"id": "INC-2", "cve_ids": ["CVE-1"], "source_ids": ["S-2"]},
+    )
+    problems = v.check_integrity(data, [])
+    assert any("CVE-1" in p and "INC-1" in p and "INC-2" in p for p in problems)
+
+
+def test_integrity_duplicate_source_flagged():
+    data = _data(
+        {"id": "INC-1", "source_ids": ["S-1"]},
+        {"id": "INC-2", "source_ids": ["S-1"]},
+    )
+    assert any("S-1" in p for p in v.check_integrity(data, []))
+
+
+def test_integrity_deprecation_resolves_via_chain():
+    data = _data({"id": "INC-3", "cve_ids": [], "source_ids": []})
+    deps = [
+        {"from": "INC-1", "into": "INC-2"},
+        {"from": "INC-2", "into": "INC-3"},  # chain INC-1 -> INC-2 -> INC-3 (live)
+    ]
+    assert v.check_integrity(data, deps) == []
+
+
+def test_integrity_deprecation_dangling_flagged():
+    data = _data({"id": "INC-3"})
+    deps = [{"from": "INC-1", "into": "INC-9"}]  # INC-9 not live
+    assert any("does not resolve" in p for p in v.check_integrity(data, deps))
+
+
+def test_integrity_deprecated_id_still_live_flagged():
+    data = _data({"id": "INC-1"})
+    deps = [{"from": "INC-1", "into": "INC-1"}]
+    assert any("still a live entry" in p for p in v.check_integrity(data, deps))
+
+
+def test_integrity_deprecation_cycle_does_not_hang():
+    data = _data({"id": "INC-3"})
+    deps = [
+        {"from": "INC-1", "into": "INC-2"},
+        {"from": "INC-2", "into": "INC-1"},  # cycle, neither resolves to live
+    ]
+    problems = v.check_integrity(data, deps)
+    assert any("does not resolve" in p for p in problems)


### PR DESCRIPTION
Promotes the manual audit I ran when fixing the dedupe tombstone bug into an automated CI gate.

`check_integrity()` (in `validate.py`, run after schema validation) fails the build on:
1. any **CVE id** held by two live entries,
2. any **source_id** held by two live entries — both are the silent-content-split signature of the tombstone bug,
3. any **`id_deprecations` `from`** that doesn't resolve through its `into` chain to a live entry, or a deprecated id that's still live — so every old citation lands somewhere real and unambiguous.

Current data passes clean (9,209 entries, no duplicate keys, all deprecations resolve). 7 new unit tests cover duplicates, chained deprecations, dangling targets, and cycle-guarding. No data changes — pure guard rail.