### PR TITLE
ci(pages): custom Jekyll build to scale past 12k incident pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,10 +35,21 @@ jobs:
       - name: Generate STIX 2.1 bundle for download
         run: python scripts/export_stix.py
       - uses: actions/configure-pages@v5
-      - uses: actions/jekyll-build-pages@v1
+      # Custom Jekyll build instead of actions/jekyll-build-pages: the managed
+      # action pins the github-pages metagem whose jekyll-relative-links plugin
+      # rewrites links across every page and took 400+ s at ~9k incident pages,
+      # so the build no longer finished at 12k+. Our docs/Gemfile pulls only
+      # Jekyll core + minima (no relative-links / optional-front-matter /
+      # readme-index / titles-from-headings / …), so the build scales.
+      - uses: ruby/setup-ruby@v1
         with:
-          source: docs
-          destination: ./_site
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: docs
+      - name: Build site with Jekyll
+        run: bundle exec jekyll build --source docs --destination ./_site --trace
+        env:
+          JEKYLL_ENV: production
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./_site

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,15 @@
+# Minimal Jekyll build for the Pages site. We deliberately do NOT use the
+# github-pages metagem: its fixed plugin set includes jekyll-relative-links,
+# which rewrites markdown links across every page and took 400+ seconds at
+# ~9k incident pages, so the managed build no longer finishes at 12k+. Our
+# layouts are standalone HTML (no SEO/feed Liquid tags; OG/Twitter meta is
+# hardcoded), so plain Jekyll + the minima theme is all we need.
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "minima", "~> 2.5"
+# Jekyll 4 needs the GFM parser explicitly for `markdown: kramdown` GFM input.
+gem "kramdown-parser-gfm", "~> 1.1"
+
+# JRuby/Windows timezone data (harmless on CI).
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]


### PR DESCRIPTION
**Fixes the stalled Pages deploys.** The managed `actions/jekyll-build-pages` pins the github-pages metagem, whose `jekyll-relative-links` plugin rewrites links across every page — it took **400+ seconds at ~9k pages** and stopped finishing entirely at 12k+ (recent deploys hung 90+ minutes before cancellation; the site has been stale at 8,179).

Replaces it with:
- `docs/Gemfile`: Jekyll 4 core + minima + kramdown-gfm only — **none** of the slow github-pages plugins (relative-links, optional-front-matter, readme-index, titles-from-headings). Verified safe: the site's layouts are standalone HTML with no SEO/feed Liquid tags, and the only internal `.md` link is a repo breadcrumb.
- `bundle exec jekyll build` via `ruby/setup-ruby` with bundler caching.

**Validated in a Ruby container at the current 12,062 incidents: full build in 56 seconds** (12,094 HTML files incl. all per-incident pages + index.html), down from a 90-minute hang.

Follow-up (separate PR) will drop the 12k per-incident pages entirely in favour of client-side detail rendering, for permanent scalability.