### PR TITLE
ci(pages): fix Gemfile path in Jekyll build step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,9 +47,12 @@ jobs:
           bundler-cache: true
           working-directory: docs
       - name: Build site with Jekyll
+        # The Gemfile lives in docs/; point bundler at it while keeping the
+        # source/destination paths repo-root-relative.
         run: bundle exec jekyll build --source docs --destination ./_site --trace
         env:
           JEKYLL_ENV: production
+          BUNDLE_GEMFILE: ${{ github.workspace }}/docs/Gemfile
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./_site


### PR DESCRIPTION
Follow-up to #51. The custom build step ran `bundle exec` from the repo root but `docs/Gemfile` is in `docs/`, so the deploy failed with `Could not locate Gemfile or .bundle/ directory` (exit 10). `setup-ruby`'s `working-directory: docs` only scoped the dependency-cache step, not the build run step.

Fix: set `BUNDLE_GEMFILE=${{ github.workspace }}/docs/Gemfile` on the build step, keeping `--source docs --destination ./_site` repo-relative. (The 56s container build worked because it ran `cd docs && bundle exec`.)