### PR TITLE
docs(readme): live incident-count badge

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Re-render INCIDENTS.md and ensure no drift
         run: |
           python scripts/render_markdown.py
-          paths="INCIDENTS.md data/incidents.json data/incidents.min.json data/id_deprecations.json docs/incidents docs/data docs/charts src/genai_incidents/data src/genai_incidents/schema"
+          paths="INCIDENTS.md data/incidents.json data/incidents.min.json data/id_deprecations.json data/stats.json docs/incidents docs/data docs/charts src/genai_incidents/data src/genai_incidents/schema"
           if [ -n "$(git status --porcelain $paths)" ]; then
             echo "::error::Generated files are out of date. Run 'make build' locally and commit the result."
             git status --porcelain $paths

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # GenAI & Agentic AI Security Incidents
 
+[![Incidents](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Femmanuelgjr%2Fgenai_incidents%2Fmain%2Fdata%2Fstats.json&query=%24.incident_count&label=incidents&color=ffb000&logo=databricks&logoColor=white)](https://emmanuelgjr.github.io/genai_incidents/)
 [![Validate dataset](https://github.com/emmanuelgjr/genai_incidents/actions/workflows/validate.yml/badge.svg)](https://github.com/emmanuelgjr/genai_incidents/actions/workflows/validate.yml)
 [![PyPI version](https://img.shields.io/pypi/v/genai-incidents?logo=pypi&logoColor=white&label=pypi)](https://pypi.org/project/genai-incidents/)
 [![Python versions](https://img.shields.io/pypi/pyversions/genai-incidents?logo=python&logoColor=white)](https://pypi.org/project/genai-incidents/)
@@ -16,7 +17,7 @@
 - 🪪 **DOI:** [`10.5281/zenodo.20248676`](https://doi.org/10.5281/zenodo.20248676) — see [`CITATION.cff`](CITATION.cff)
 - 📜 **Changelog:** [`CHANGELOG.md`](CHANGELOG.md)
 
-A single source of truth for **GenAI and agentic AI security incidents**, mapped to:
+A single source of truth of **[12,000+ GenAI and agentic AI security incidents](https://emmanuelgjr.github.io/genai_incidents/)** (see the live count in the badge above), each mapped to:
 
 - **OWASP Top 10 for LLM Applications (2025)** — `LLM01`–`LLM10`
 - **OWASP Agentic Top 10 (ASI)** — `ASI01`–`ASI10`

--- a/data/stats.json
+++ b/data/stats.json
@@ -1,0 +1,7 @@
+{
+  "incident_count": 12062,
+  "version": "2.2.0",
+  "generated": "2026-06-10",
+  "year_min": 1983,
+  "year_max": 2026
+}

--- a/scripts/render_markdown.py
+++ b/scripts/render_markdown.py
@@ -496,6 +496,19 @@ def render():
     entries = list(raw["incidents"])
     entries.sort(key=sort_key)
 
+    # Tiny stats file for the README's live incident-count badge (shields.io
+    # dynamic JSON reads it). Kept small so the badge endpoint is fast, and
+    # regenerated every build so it never drifts from the dataset.
+    years = sorted({e.get("year") for e in entries if e.get("year")})
+    stats = {
+        "incident_count": raw.get("incident_count", len(entries)),
+        "version": raw.get("version", ""),
+        "generated": raw.get("generated", ""),
+        "year_min": years[0] if years else None,
+        "year_max": years[-1] if years else None,
+    }
+    _write_lf(DATA / "stats.json", json.dumps(stats, indent=2))
+
     llm_counts: Counter = Counter()
     asi_counts: Counter = Counter()
     atlas_counts: Counter = Counter()


### PR DESCRIPTION
Adds a visible incident count to the README (your ask).

- `render_markdown.py` writes a small **`data/stats.json`** (`incident_count`, `version`, `generated`, year range) on every build — added to the drift-checked paths so it can't go stale.
- README gains a **shields.io dynamic-JSON badge** reading that file (amber to match the site), plus a count in the intro line. The badge updates automatically after each weekly refresh; no manual bumping.

Renders 12,062 today.