### PR TITLE
chore(release): bump version to 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ The dataset uses [SemVer](https://semver.org/) — major bumps for breaking
 schema or ID changes, minor bumps for additive schema fields or large
 ingest expansions, patch bumps for routine refreshes and bug fixes.
 
+## [2.3.0] — 2026-06-10
+
+### Added
+
+- **9,209 → 12,062 incidents.** Deeper GitHub Security Advisory ingest
+  (paged back to the 2022 floor) plus a new **MALWARE-classification
+  pass** that surfaced **465 malicious-package** advisories (AI-ecosystem
+  typosquats / trojaned deps), and ~31 new NVD keywords + OSV packages
+  for high-CVE-count AI products (Langflow, LiteLLM, LangGraph, NeMo,
+  DeepSpeed, vLLM, llama.cpp, …).
+- **CISA KEV enrichment**: `exploited_in_wild` + `kev_date_added` flag
+  incidents whose CVEs are in the Known Exploited Vulnerabilities catalog
+  (deterministic, from a committed snapshot refreshed by the workflows).
+- New `exploited_in_wild` / `kev_date_added` schema fields. README now
+  carries a live incident-count badge fed by `data/stats.json`.
+
+### Security
+
+- **Fixed a stored XSS** on the generated incident pages: advisory
+  descriptions containing raw HTML (e.g. `<img src=x onerror=...>`)
+  executed when rendered as Markdown. All incident free-text is now
+  HTML-escaped and link schemes are restricted to http(s)/mailto; a CI
+  guard fails the build if raw HTML reaches a shard.
+
+### Changed
+
+- **Site rebuilt to scale**: custom Jekyll build (the managed builder
+  stopped finishing at 12k pages) and the per-incident standalone pages
+  were retired in favour of self-anchored year shards + client-side
+  detail. Added a **light/dark theme** toggle.
+- CI hardened: cross-entry integrity invariants (no CVE/source held by
+  two live entries; deprecations resolve) and UTC-stable date stamps.
+
 ## [2.2.0] — 2026-06-10
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,7 +33,7 @@ abstract: >-
   Framework (AI 100-1), and MITRE ATLAS. Aggregated from AIID, OECD AIM,
   AIAAIC, MITRE ATLAS, AVID, MIT FutureTech AI Risk Navigator, NVD/GHSA/OSV,
   garak, promptfoo, and dozens of researcher blogs and vendor threat reports.
-version: "2.2.0"
+version: "2.3.0"
 date-released: "2026-06-10"
 preferred-citation:
   type: dataset
@@ -43,6 +43,6 @@ preferred-citation:
       given-names: "Emmanuel"
       alias: "emmanuelgjr"
   year: 2026
-  version: "2.2.0"
+  version: "2.3.0"
   doi: 10.5281/zenodo.20248676
   url: "https://doi.org/10.5281/zenodo.20248676"

--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -3,7 +3,7 @@
 Single source of truth for GenAI and agentic AI security incidents.
 Each entry is mapped to **OWASP LLM Top 10 (2025)**, **OWASP Agentic Top 10 (ASI)**, **NIST AI RMF**, and **MITRE ATLAS**.
 
-- **Version:** 2.2.0
+- **Version:** 2.3.0
 - **Generated:** 2026-06-10
 - **Total incidents:** **12,062**
 - **Date range:** 1983 – 2026

--- a/data/incidents.min.json
+++ b/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.3.0",
   "generated": "2026-06-10",
   "incident_count": 12062,
   "incidents": [

--- a/data/stats.json
+++ b/data/stats.json
@@ -1,6 +1,6 @@
 {
   "incident_count": 12062,
-  "version": "2.2.0",
+  "version": "2.3.0",
   "generated": "2026-06-10",
   "year_min": 1983,
   "year_max": 2026

--- a/docs/data/incidents.min.json
+++ b/docs/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.3.0",
   "generated": "2026-06-10",
   "incident_count": 12062,
   "incidents": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genai-incidents"
-version = "2.2.0"
+version = "2.3.0"
 description = "Curated dataset of GenAI & agentic-AI security incidents mapped to OWASP LLM Top 10, OWASP Agentic Top 10, NIST AI RMF, and MITRE ATLAS."
 readme = "README.md"
 license = "MIT"

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -1212,7 +1212,7 @@ def main():
 
     # 9) Write outputs
     out = {
-        "version": "2.2.0",
+        "version": "2.3.0",
         "generated": generated,
         "description": (
             "Single source of truth for GenAI and agentic AI security incidents. "

--- a/src/genai_incidents/data/incidents.min.json
+++ b/src/genai_incidents/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.0",
+  "version": "2.3.0",
   "generated": "2026-06-10",
   "incident_count": 12062,
   "incidents": [


### PR DESCRIPTION
Version bump for the **v2.3.0** release across all four version sites (`pyproject.toml`, the data `version` string in `merge_and_dedupe.py`, `CITATION.cff` ×2 + `date-released`), full container rebuild, and a CHANGELOG entry.

Since 2.2.0 (9,209): **12,062 incidents** — deeper GHSA + the MALWARE pass (+465 malicious packages), CISA KEV enrichment, the stored-XSS fix, the site rebuilt to scale + light/dark theme, and CI integrity invariants.

After merge: tagging **v2.3.0** → the release event auto-publishes PyPI (`publish.yml`) and Hugging Face (`huggingface.yml`); Zenodo mints a new version DOI. Verified: 12,062 valid, integrity clean.