### PR TITLE
validate: evidence + scope CI gates (Pillar 1 — automate the precision lesson)

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -17,6 +18,20 @@ except ImportError:
     )
     sys.exit(2)
 
+# Inclusion-policy gate: reuse the one strict matcher (INCLUSION.md §4).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from merge_and_dedupe import is_out_of_scope_malware
+except Exception:  # pragma: no cover - keep validate runnable in isolation
+    is_out_of_scope_malware = None  # type: ignore
+
+_RESOLVABLE_URL = re.compile(r"^(https?://|mailto:)", re.I)
+
+
+def _has_primary_source(entry: dict) -> bool:
+    return any(_RESOLVABLE_URL.match((r.get("url") or "").strip())
+              for r in (entry.get("references") or []))
+
 
 def check_integrity(data: dict, deprecations: list[dict] | None = None) -> list[str]:
     """Cross-entry invariants the JSON schema can't express. Returns a list
@@ -28,9 +43,13 @@ def check_integrity(data: dict, deprecations: list[dict] | None = None) -> list[
          2026-06 dedupe tombstone bug. This is the machine check for the
          audit done by hand when that bug was fixed.
     3.   id_deprecations referential integrity: every deprecated `from` id
-         must resolve through its `into` chain to a live entry, and no
-         deprecated id may still be live (an old citation must land
-         somewhere real and unambiguous).
+         must resolve through its `into` chain to a live entry (or be an
+         `into:null` removal), and no deprecated id may still be live.
+    4.   Evidence gate (INCLUSION.md): every entry must carry at least one
+         resolvable http(s)/mailto primary-source reference.
+    5.   Scope gate (INCLUSION.md): no out-of-scope malicious-package entry
+         may survive — makes the v2.3.1 scope-purge a hard, enforced
+         invariant so the generic-malware noise can never return.
     """
     problems: list[str] = []
     incidents = data["incidents"]
@@ -46,6 +65,23 @@ def check_integrity(data: dict, deprecations: list[dict] | None = None) -> list[
                     )
                 else:
                     holders[key] = e["id"]
+
+    # 4) Evidence gate — every entry needs a resolvable primary source.
+    no_source = [e["id"] for e in incidents if not _has_primary_source(e)]
+    if no_source:
+        problems.append(
+            f"{len(no_source)} entr(ies) lack a resolvable primary source "
+            f"(e.g. {', '.join(no_source[:5])})"
+        )
+
+    # 5) Scope gate — no out-of-scope malicious-package entry may survive.
+    if is_out_of_scope_malware is not None:
+        oos = [e["id"] for e in incidents if is_out_of_scope_malware(e)]
+        if oos:
+            problems.append(
+                f"{len(oos)} out-of-scope malicious-package entr(ies) survived the "
+                f"scope purge (e.g. {', '.join(oos[:5])})"
+            )
 
     if deprecations is not None:
         into_map = {d.get("from"): d.get("into") for d in deprecations}

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -6,6 +6,10 @@ import validate as v
 
 
 def _data(*incidents):
+    # Default a resolvable reference so fixtures pass the evidence gate unless
+    # a test is specifically exercising it.
+    for e in incidents:
+        e.setdefault("references", [{"url": "https://example.com/src"}])
     return {"incidents": list(incidents)}
 
 
@@ -63,3 +67,21 @@ def test_integrity_deprecation_cycle_does_not_hang():
     ]
     problems = v.check_integrity(data, deps)
     assert any("does not resolve" in p for p in problems)
+
+
+def test_integrity_evidence_gate_flags_sourceless():
+    data = _data({"id": "INC-1", "references": []})
+    assert any("primary source" in p for p in v.check_integrity(data, []))
+    ok = _data({"id": "INC-1", "references": [{"url": "https://x.com/a"}]})
+    assert not any("primary source" in p for p in v.check_integrity(ok, []))
+
+
+def test_integrity_scope_gate_flags_out_of_scope_malware():
+    data = _data({"id": "INC-1", "tags": ["malicious-package"],
+                  "affected": "npm/chai-mocks",
+                  "references": [{"url": "https://x.com/a"}]})
+    assert any("out-of-scope" in p for p in v.check_integrity(data, []))
+    ok = _data({"id": "INC-1", "tags": ["malicious-package"],
+                "affected": "npm/@langchain/core",
+                "references": [{"url": "https://x.com/a"}]})
+    assert not any("out-of-scope" in p for p in v.check_integrity(ok, []))


### PR DESCRIPTION
Turns this session's two by-hand checks into **permanent, enforced CI invariants** (`check_integrity` runs in the validate, CVE-enrich, and weekly-refresh workflows):

1. **Evidence gate** — every entry must carry at least one resolvable `http(s)`/`mailto` primary-source reference. Codifies INCLUSION.md's evidence requirement; no source → build fails.
2. **Scope gate** — no out-of-scope `malicious-package` entry may survive. Makes the v2.3.1 scope-purge a *hard invariant*: if the generic-malware noise ever tried to return, CI fails instead of shipping it.

Both reuse the single strict matcher (`is_out_of_scope_malware` → `package_is_strongly_ai`) so the policy lives in one place. Current data passes both (0 sourceless, 0 out-of-scope). Code-only; 123 tests pass (4 new). Security self-review: only an anchored linear regex + local import added.