### PR TITLE
docs(trust): corrections process — templates + public log (Pillar 1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Inclusion policy (what's in scope)
+    url: https://github.com/emmanuelgjr/genai_incidents/blob/main/INCLUSION.md
+    about: Read the scope contract before filing a scope dispute.
+  - name: Corrections log
+    url: https://github.com/emmanuelgjr/genai_incidents/blob/main/CORRECTIONS.md
+    about: Public record of accepted corrections and removals.

--- a/.github/ISSUE_TEMPLATE/data_correction.yml
+++ b/.github/ISSUE_TEMPLATE/data_correction.yml
@@ -1,0 +1,41 @@
+name: Data correction
+description: Report a factual error in an existing incident (wrong field, bad mapping, dead source, duplicate)
+labels: [correction]
+body:
+  - type: input
+    id: incident_id
+    attributes:
+      label: Incident ID
+      description: The INC-xxxxx id of the affected entry (or the title if unknown).
+      placeholder: "INC-01234"
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What's wrong?
+      options:
+        - Wrong / outdated field value
+        - Incorrect framework mapping (OWASP / NIST / ATLAS)
+        - Wrong severity or attack vector
+        - Dead or wrong primary-source link
+        - Duplicate of another incident
+        - Mis-attributed vendor / product
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: correction
+    attributes:
+      label: The correction
+      description: What it currently says, what it should say, and why.
+    validations:
+      required: true
+  - type: input
+    id: evidence
+    attributes:
+      label: Evidence (primary source URL)
+      description: A citable source supporting the correction. Required — entries must be evidence-backed (see INCLUSION.md).
+      placeholder: "https://…"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/scope_dispute.yml
+++ b/.github/ISSUE_TEMPLATE/scope_dispute.yml
@@ -1,0 +1,34 @@
+name: Scope dispute
+description: Argue that an entry should be included or excluded under the inclusion policy
+labels: [scope]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Scope is governed by [INCLUSION.md](../../INCLUSION.md). An entry must
+        satisfy three gates: **AI-nexus**, **security/safety relevance**, and
+        **evidence**. Disputes are resolved by PR against that policy.
+  - type: dropdown
+    id: direction
+    attributes:
+      label: You are arguing to…
+      options:
+        - Exclude an entry that's currently in (out of scope)
+        - Include something that's currently out (in scope)
+        - Clarify / change the policy itself
+    validations:
+      required: true
+  - type: input
+    id: subject
+    attributes:
+      label: Incident ID or candidate
+      placeholder: "INC-01234  or  CVE-2026-xxxxx / package name"
+    validations:
+      required: true
+  - type: textarea
+    id: argument
+    attributes:
+      label: Which gate fails / passes, and why
+      description: Reference the specific INCLUSION.md gate(s) and give your reasoning + evidence.
+    validations:
+      required: true

--- a/CORRECTIONS.md
+++ b/CORRECTIONS.md
@@ -1,0 +1,19 @@
+# Corrections log
+
+A public, append-only record of accepted data corrections and removals — what
+changed, why, and the evidence. An authoritative dataset is one you can
+*correct*; this log makes every correction transparent and auditable.
+
+How to propose one: open a [Data correction](https://github.com/emmanuelgjr/genai_incidents/issues/new?template=data_correction.yml)
+or [Scope dispute](https://github.com/emmanuelgjr/genai_incidents/issues/new?template=scope_dispute.yml)
+issue. Accepted changes are applied via PR and logged here. Removed incident IDs
+are also recorded in [`data/id_deprecations.json`](data/id_deprecations.json) so
+old citations still resolve.
+
+| Date | Change | Scope | Reason | Evidence / PR |
+|------|--------|-------|--------|---------------|
+| 2026-06-11 | **Removed ~800 out-of-scope `malicious-package` entries** (e.g. `chai-mocks`, `sudo-prompt`, `nemo-reporter`) | bulk removal | Generic npm malware matched on weak substrings (`ai`, `prompt`, `nemo`); not AI incidents per [INCLUSION.md](INCLUSION.md). malicious-package 465 → 61. | PR #63 (v2.3.1); recorded as `out-of-scope` removals in `id_deprecations.json` |
+| 2026-06-10 | Removed `CVE-2026-35020` | single removal | CNA-rejected (withdrawn from NVD). | v2.2.0 enrichment |
+| 2026-06-10 | Removed MITRE ATLAS technique `AML.T0039` | mapping fix | Phantom technique — never existed in any ATLAS release (duplicated T0048). | PR #26 |
+
+_Newest first. Each row links to the PR and, for removals, the deprecation record._

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - 🛰️ **STIX 2.1 bundle** (for OpenCTI / MISP / TAXII): <https://emmanuelgjr.github.io/genai_incidents/data/incidents.stix.json> — incidents as `x-genai-incident` SDOs linked to MITRE ATLAS `attack-pattern`s and CVE `vulnerability`s. Build locally with `make stix`.
 - 📖 **Field reference:** [`docs/DATA_DICTIONARY.md`](docs/DATA_DICTIONARY.md) · **Provenance & limitations:** [`docs/DATASHEET.md`](docs/DATASHEET.md)
 - 🎯 **Scope — what's in/out:** [`INCLUSION.md`](INCLUSION.md) (the inclusion policy every entry must satisfy)
+- 🛠️ **Spot an error?** Open a [data correction](https://github.com/emmanuelgjr/genai_incidents/issues/new?template=data_correction.yml) or [scope dispute](https://github.com/emmanuelgjr/genai_incidents/issues/new?template=scope_dispute.yml) — accepted changes are logged in [`CORRECTIONS.md`](CORRECTIONS.md)
 - 🪪 **DOI:** [`10.5281/zenodo.20248676`](https://doi.org/10.5281/zenodo.20248676) — see [`CITATION.cff`](CITATION.cff)
 - 📜 **Changelog:** [`CHANGELOG.md`](CHANGELOG.md)
 


### PR DESCRIPTION
Makes the dataset **correctable and transparent** — a core trust property.

- **`data_correction.yml`** — report a factual error (wrong field, bad mapping, dead source, duplicate) with required evidence.
- **`scope_dispute.yml`** — argue an entry in/out against the INCLUSION.md gates.
- **`config.yml`** — surfaces INCLUSION.md + the corrections log as contact links; disables blank issues.
- **`CORRECTIONS.md`** — public, append-only log of accepted corrections/removals, seeded with the v2.3.1 noise purge and the earlier rejected-CVE / phantom-ATLAS removals. Removals also live in `id_deprecations.json` so old citations resolve.
- README links both report flows.

Docs/config only.