### PR TITLE
feat(trust): provenance fields — confidence, source_count/status, first/last_seen (Pillar 1)

### DIFF
--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -9,8 +9,12 @@ Every incident in [`data/incidents.json`](../data/incidents.json) follows
 | `id` **R** | string | Stable incident id, `INC-#####`. Never reused; merged-away ids are recorded in [`data/id_deprecations.json`](../data/id_deprecations.json) and resolvable via the package's `resolve_id()`. |
 | `source_ids` | string[] | Upstream ids this entry was consolidated from (e.g. `AIID-1234`, `CVE-2026-…`, `ATLAS-AML.CS0001`, `AIAAIC2257`). |
 | `quality_tier` | enum | Vetting level: `curated` (hand-written/maintainer), `reviewed` (maintained catalogue, NVD-scored CVE, hand-picked, or human/assisted review), `auto` (bulk-ingested). Filter on this to control trust. |
+| `confidence` | enum | Rule-derived, not opinion: **high** = `curated`/`reviewed`, OR 2+ sources with a CVE; **medium** = 2+ sources, OR has a CVE/CVSS; **low** = a single `auto` source, no CVE. |
+| `source_count` | int | Number of distinct upstream sources corroborating the entry. |
+| `source_status` | enum | `active` (still emitted by a source this build) or `retained` (carried from a prior build after all its sources dropped it — see retain-on-drop). |
 | `corpus` | enum | `security` (exploit/vuln/misuse) or `ai-harm` (societal harm without a security primitive). |
 | `added` / `updated` | date | First-added / last-content-change dates (content-gated, so unchanged entries don't churn). |
+| `first_seen` / `last_seen` | date | Provenance aliases of `added` / `updated`. |
 
 ## Core description
 | Field | Type | Notes |

--- a/schema/incident.schema.json
+++ b/schema/incident.schema.json
@@ -104,6 +104,31 @@
       "description": "How well-vetted the entry is. `curated` = hand-written or maintainer-reviewed; `reviewed` = sourced from a maintained research catalogue; `auto` = bulk-ingested.",
       "enum": ["curated", "reviewed", "auto"]
     },
+    "confidence": {
+      "type": "string",
+      "description": "Transparent, rule-derived confidence in the entry (see DATA_DICTIONARY.md). high = curated/reviewed OR 2+ distinct sources with a CVE; medium = 2+ sources OR has a CVE/CVSS; low = a single auto-tier source.",
+      "enum": ["high", "medium", "low"]
+    },
+    "source_count": {
+      "type": "integer",
+      "description": "Number of distinct upstream sources (source_ids) corroborating the entry.",
+      "minimum": 0
+    },
+    "source_status": {
+      "type": "string",
+      "description": "Whether the entry is still emitted by at least one source on the latest build (`active`) or was retained from a prior build after all its sources dropped it (`retained`).",
+      "enum": ["active", "retained"]
+    },
+    "first_seen": {
+      "type": "string",
+      "description": "Date the entry first entered the dataset (provenance alias of `added`).",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "last_seen": {
+      "type": "string",
+      "description": "Date the entry's content was last confirmed/updated from a source (provenance alias of `updated`).",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
     "corpus": {
       "type": "string",
       "description": "Which sub-corpus the entry belongs to. `security` = exploitation, vulnerability, misuse; `ai-harm` = bias/discrimination/social harm without a security primitive.",

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -45,6 +45,23 @@ def is_out_of_scope_malware(entry: dict) -> bool:
     return not any(package_is_strongly_ai(p) for p in pkgs)
 
 
+def _derive_confidence(entry: dict) -> str:
+    """Transparent, rule-based confidence (documented in DATA_DICTIONARY.md):
+      high   = curated/reviewed tier, OR 2+ distinct sources AND a CVE;
+      medium = 2+ distinct sources, OR has a CVE / CVSS score;
+      low    = a single auto-tier source with no CVE.
+    A rule, not an opinion — disputable via the corrections process."""
+    n_src = len(entry.get("source_ids") or [])
+    has_cve = bool(entry.get("cve_ids"))
+    has_cvss = entry.get("cvss_score") is not None
+    tier = entry.get("quality_tier")
+    if tier in ("curated", "reviewed") or (n_src >= 2 and has_cve):
+        return "high"
+    if n_src >= 2 or has_cve or has_cvss:
+        return "medium"
+    return "low"
+
+
 def utc_today() -> date:
     """Calendar date in UTC. CI builds run in UTC; a contributor whose local
     clock lags UTC must stamp the same dates as a same-UTC-day CI build, or
@@ -1196,6 +1213,7 @@ def main():
             continue
         if (keys & covered_keys) or pid in used_ids:
             continue
+        prior["source_status"] = "retained"  # carried after all sources dropped it
         surviving.append(prior)
         covered_keys.update(keys)
         used_ids.add(pid)
@@ -1221,6 +1239,19 @@ def main():
         print(f"[retention] WARNING: {no_keys} eligible prior(s) had no source_id/cve_id and could not be retained")
 
     deduped = surviving
+
+    # 6g) Provenance fields (INCLUSION.md trust layer). Pure, deterministic
+    #     derivations of already-finalised fields — set AFTER history stamping
+    #     and kept OUT of the content snapshot, so they never perturb the
+    #     `updated`/drift logic. See DATA_DICTIONARY.md for the confidence rule.
+    for e in deduped:
+        e["source_count"] = len(e.get("source_ids") or [])
+        e["confidence"] = _derive_confidence(e)
+        e.setdefault("source_status", "active")
+        if e.get("added"):
+            e["first_seen"] = e["added"]
+        if e.get("updated"):
+            e["last_seen"] = e["updated"]
 
     print(f"\n[total]  {len(all_entries)} input -> {len(deduped)} unique")
 

--- a/src/genai_incidents/schema/incident.schema.json
+++ b/src/genai_incidents/schema/incident.schema.json
@@ -104,6 +104,31 @@
       "description": "How well-vetted the entry is. `curated` = hand-written or maintainer-reviewed; `reviewed` = sourced from a maintained research catalogue; `auto` = bulk-ingested.",
       "enum": ["curated", "reviewed", "auto"]
     },
+    "confidence": {
+      "type": "string",
+      "description": "Transparent, rule-derived confidence in the entry (see DATA_DICTIONARY.md). high = curated/reviewed OR 2+ distinct sources with a CVE; medium = 2+ sources OR has a CVE/CVSS; low = a single auto-tier source.",
+      "enum": ["high", "medium", "low"]
+    },
+    "source_count": {
+      "type": "integer",
+      "description": "Number of distinct upstream sources (source_ids) corroborating the entry.",
+      "minimum": 0
+    },
+    "source_status": {
+      "type": "string",
+      "description": "Whether the entry is still emitted by at least one source on the latest build (`active`) or was retained from a prior build after all its sources dropped it (`retained`).",
+      "enum": ["active", "retained"]
+    },
+    "first_seen": {
+      "type": "string",
+      "description": "Date the entry first entered the dataset (provenance alias of `added`).",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "last_seen": {
+      "type": "string",
+      "description": "Date the entry's content was last confirmed/updated from a source (provenance alias of `updated`).",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
     "corpus": {
       "type": "string",
       "description": "Which sub-corpus the entry belongs to. `security` = exploitation, vulnerability, misuse; `ai-harm` = bias/discrimination/social harm without a security primitive.",

--- a/tests/test_merge_and_dedupe.py
+++ b/tests/test_merge_and_dedupe.py
@@ -686,3 +686,24 @@ def test_is_out_of_scope_malware_ignores_non_malware():
         {"tags": ["cve"], "affected": "npm/chai-mocks"}) is False
     assert m.is_out_of_scope_malware(
         {"tags": ["malicious-package"], "affected": ""}) is False
+
+
+# ---------------------------------------------------------------------------
+# Provenance fields (Pillar 1 trust layer)
+# ---------------------------------------------------------------------------
+
+def test_derive_confidence_rule():
+    assert m._derive_confidence({"quality_tier": "curated"}) == "high"
+    assert m._derive_confidence({"quality_tier": "reviewed"}) == "high"
+    assert m._derive_confidence({"quality_tier": "auto", "source_ids": ["A", "B"],
+                                 "cve_ids": ["CVE-1"]}) == "high"
+    assert m._derive_confidence({"quality_tier": "auto", "source_ids": ["A", "B"]}) == "medium"
+    assert m._derive_confidence({"quality_tier": "auto", "source_ids": ["A"],
+                                 "cvss_score": 7.5}) == "medium"
+    assert m._derive_confidence({"quality_tier": "auto", "source_ids": ["A"]}) == "low"
+
+
+def test_provenance_fields_not_in_content_snapshot():
+    # Must stay out of the snapshot so they never spuriously bump `updated`.
+    for f in ("source_count", "confidence", "source_status", "first_seen", "last_seen"):
+        assert f not in m._CONTENT_FIELDS


### PR DESCRIPTION
Final Pillar-1 (Trust) data piece: every entry now carries **rule-derived, deterministic provenance**.

- **`confidence`** (high/medium/low) from a transparent, documented rule over `quality_tier` + distinct source count + CVE/CVSS presence — a rule, not an opinion, disputable via the corrections process. Distribution on current data: 9,710 high / 653 medium / 1,295 low.
- **`source_count`**, **`source_status`** (`active` vs `retained`-after-drop).
- **`first_seen`/`last_seen`** (provenance aliases of added/updated).

Set after history stamping and kept **out of the content snapshot**, so they never perturb the `updated`/drift logic. Verified in container: 11,658 unchanged, **idempotent**, validate + integrity clean. Schema + DATA_DICTIONARY updated; tests added.