### PR TITLE
chore(release): v2.4.0 — Trust foundation (governance + provenance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ The dataset uses [SemVer](https://semver.org/) — major bumps for breaking
 schema or ID changes, minor bumps for additive schema fields or large
 ingest expansions, patch bumps for routine refreshes and bug fixes.
 
+## [2.4.0] — 2026-06-11
+
+### Added (Trust foundation)
+- **[INCLUSION.md](INCLUSION.md)** — explicit scope policy: every entry must
+  satisfy AI-nexus + security/safety-relevance + evidence gates.
+- **Provenance fields** on every entry: `confidence` (transparent
+  high/medium/low rule), `source_count`, `source_status` (active/retained),
+  `first_seen`/`last_seen`.
+- **Corrections process** — `data_correction` / `scope_dispute` issue
+  templates and a public [CORRECTIONS.md](CORRECTIONS.md) log.
+
+### Changed (enforced quality)
+- CI now enforces two cross-entry invariants on every build: every entry has
+  a resolvable primary source, and no out-of-scope malicious-package entry
+  may survive (the v2.3.1 scope-purge is now a hard gate).
+
 ## [2.3.1] — 2026-06-10
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,7 +33,7 @@ abstract: >-
   Framework (AI 100-1), and MITRE ATLAS. Aggregated from AIID, OECD AIM,
   AIAAIC, MITRE ATLAS, AVID, MIT FutureTech AI Risk Navigator, NVD/GHSA/OSV,
   garak, promptfoo, and dozens of researcher blogs and vendor threat reports.
-version: "2.3.1"
+version: "2.4.0"
 date-released: "2026-06-10"
 preferred-citation:
   type: dataset
@@ -43,6 +43,6 @@ preferred-citation:
       given-names: "Emmanuel"
       alias: "emmanuelgjr"
   year: 2026
-  version: "2.3.1"
+  version: "2.4.0"
   doi: 10.5281/zenodo.20248676
   url: "https://doi.org/10.5281/zenodo.20248676"

--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -3,7 +3,7 @@
 Single source of truth for GenAI and agentic AI security incidents.
 Each entry is mapped to **OWASP LLM Top 10 (2025)**, **OWASP Agentic Top 10 (ASI)**, **NIST AI RMF**, and **MITRE ATLAS**.
 
-- **Version:** 2.3.1
+- **Version:** 2.4.0
 - **Generated:** 2026-06-10
 - **Total incidents:** **11,658**
 - **Date range:** 1983 – 2026

--- a/data/incidents.min.json
+++ b/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1",
+  "version": "2.4.0",
   "generated": "2026-06-10",
   "incident_count": 11658,
   "incidents": [

--- a/data/stats.json
+++ b/data/stats.json
@@ -1,6 +1,6 @@
 {
   "incident_count": 11658,
-  "version": "2.3.1",
+  "version": "2.4.0",
   "generated": "2026-06-10",
   "year_min": 1983,
   "year_max": 2026

--- a/docs/data/incidents.min.json
+++ b/docs/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1",
+  "version": "2.4.0",
   "generated": "2026-06-10",
   "incident_count": 11658,
   "incidents": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genai-incidents"
-version = "2.3.1"
+version = "2.4.0"
 description = "Curated dataset of GenAI & agentic-AI security incidents mapped to OWASP LLM Top 10, OWASP Agentic Top 10, NIST AI RMF, and MITRE ATLAS."
 readme = "README.md"
 license = "MIT"

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -1301,7 +1301,7 @@ def main():
 
     # 9) Write outputs
     out = {
-        "version": "2.3.1",
+        "version": "2.4.0",
         "generated": generated,
         "description": (
             "Single source of truth for GenAI and agentic AI security incidents. "

--- a/src/genai_incidents/data/incidents.min.json
+++ b/src/genai_incidents/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.3.1",
+  "version": "2.4.0",
   "generated": "2026-06-10",
   "incident_count": 11658,
   "incidents": [


### PR DESCRIPTION
Publishes Pillar 1 of the world's-best-dataset program. Version bump across all four sites + rebuild + changelog.

Since 2.3.1: **INCLUSION.md** scope policy, per-entry **provenance** (`confidence`/`source_count`/`source_status`/`first_seen`/`last_seen`), a **corrections process**, and **CI evidence+scope gates**. 11,658 incidents. After merge: tag v2.4.0 → auto-publishes PyPI + HF; Zenodo mints a DOI.