### PR TITLE
feat(coverage): two-tier landmark vs feed (Pillar 2)

### DIFF
--- a/data/stats.json
+++ b/data/stats.json
@@ -1,5 +1,6 @@
 {
   "incident_count": 11658,
+  "landmark_count": 1837,
   "version": "2.4.0",
   "generated": "2026-06-10",
   "year_min": 1983,

--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -9,6 +9,7 @@ Every incident in [`data/incidents.json`](../data/incidents.json) follows
 | `id` **R** | string | Stable incident id, `INC-#####`. Never reused; merged-away ids are recorded in [`data/id_deprecations.json`](../data/id_deprecations.json) and resolvable via the package's `resolve_id()`. |
 | `source_ids` | string[] | Upstream ids this entry was consolidated from (e.g. `AIID-1234`, `CVE-2026-…`, `ATLAS-AML.CS0001`, `AIAAIC2257`). |
 | `quality_tier` | enum | Vetting level: `curated` (hand-written/maintainer), `reviewed` (maintained catalogue, NVD-scored CVE, hand-picked, or human/assisted review), `auto` (bulk-ingested). Filter on this to control trust. |
+| `tier` | enum | **landmark** (curated, AIID-linked real-world, ai-harm, or real-world-category — the notable headline set) vs **feed** (the comprehensive CVE/GHSA/OSV stream). Cite the landmark count for headlines. |
 | `confidence` | enum | Rule-derived, not opinion: **high** = `curated`/`reviewed`, OR 2+ sources with a CVE; **medium** = 2+ sources, OR has a CVE/CVSS; **low** = a single `auto` source, no CVE. |
 | `source_count` | int | Number of distinct upstream sources corroborating the entry. |
 | `source_status` | enum | `active` (still emitted by a source this build) or `retained` (carried from a prior build after all its sources dropped it — see retain-on-drop). |

--- a/docs/app.js
+++ b/docs/app.js
@@ -34,6 +34,7 @@ const els = {
   llm: document.getElementById('llm'),
   asi: document.getElementById('asi'),
   vector: document.getElementById('vector'),
+  tier: document.getElementById('tier'),
   corpus: document.getElementById('corpus'),
   quality: document.getElementById('quality'),
   cveOnly: document.getElementById('cve_only'),
@@ -49,11 +50,11 @@ const els = {
   exportCsv: document.getElementById('export-csv'),
 };
 
-const FILTER_KEYS = ['q','year','severity','llm','asi','vector','corpus','quality','cveOnly'];
+const FILTER_KEYS = ['q','year','severity','llm','asi','vector','tier','corpus','quality','cveOnly'];
 const FILTER_LABEL = {
   q: 'Search', year: 'Year', severity: 'Severity',
   llm: 'OWASP LLM', asi: 'OWASP ASI', vector: 'Vector',
-  corpus: 'Corpus', quality: 'Quality', cveOnly: 'CVE',
+  tier: 'Tier', corpus: 'Corpus', quality: 'Quality', cveOnly: 'CVE',
 };
 
 let DATA = [];
@@ -155,6 +156,7 @@ function matches(e) {
   if (els.asi.value      && !(e.owasp_asi || []).includes(els.asi.value)) return false;
   if (els.vector.value   && e.attack_vector !== els.vector.value) return false;
   if (els.corpus.value   && e.corpus !== els.corpus.value)      return false;
+  if (els.tier && els.tier.value && e.tier !== els.tier.value) return false;
   if (els.quality.value  && e.quality_tier !== els.quality.value) return false;
   if (els.cveOnly.checked && !(e.cve_ids || []).length)         return false;
   const q = els.q.value.trim().toLowerCase();

--- a/docs/index.html
+++ b/docs/index.html
@@ -155,6 +155,14 @@
           <select id="vector"><option value="">all</option></select>
         </div>
         <div class="filter">
+          <label for="tier">Tier</label>
+          <select id="tier">
+            <option value="">all</option>
+            <option value="landmark">landmark</option>
+            <option value="feed">feed</option>
+          </select>
+        </div>
+        <div class="filter">
           <label for="corpus">Corpus</label>
           <select id="corpus">
             <option value="">all</option>

--- a/schema/incident.schema.json
+++ b/schema/incident.schema.json
@@ -109,6 +109,11 @@
       "description": "Transparent, rule-derived confidence in the entry (see DATA_DICTIONARY.md). high = curated/reviewed OR 2+ distinct sources with a CVE; medium = 2+ sources OR has a CVE/CVSS; low = a single auto-tier source.",
       "enum": ["high", "medium", "low"]
     },
+    "tier": {
+      "type": "string",
+      "description": "Curated/notable `landmark` incidents vs the comprehensive vulnerability/advisory `feed` (INCLUSION.md §5). landmark = curated, AIID-linked real-world, ai-harm, or real-world-category; feed = the CVE/GHSA/OSV bulk. Cite the landmark count for headlines.",
+      "enum": ["landmark", "feed"]
+    },
     "source_count": {
       "type": "integer",
       "description": "Number of distinct upstream sources (source_ids) corroborating the entry.",

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -45,6 +45,20 @@ def is_out_of_scope_malware(entry: dict) -> bool:
     return not any(package_is_strongly_ai(p) for p in pkgs)
 
 
+def _derive_tier(entry: dict) -> str:
+    """Two-tier split (INCLUSION.md §5): the curated/notable LANDMARK set vs
+    the comprehensive vulnerability/advisory FEED. landmark = hand-curated, a
+    real-world incident (AIID-linked), an AI-harm case, or a real-world-category
+    event; feed = the CVE/GHSA/OSV bulk. Headline claims should cite the
+    landmark count, not the raw total."""
+    if (entry.get("quality_tier") == "curated"
+            or entry.get("aiid_id")
+            or entry.get("corpus") == "ai-harm"
+            or entry.get("category") == "real-world"):
+        return "landmark"
+    return "feed"
+
+
 def _derive_confidence(entry: dict) -> str:
     """Transparent, rule-based confidence (documented in DATA_DICTIONARY.md):
       high   = curated/reviewed tier, OR 2+ distinct sources AND a CVE;
@@ -1245,6 +1259,7 @@ def main():
     #     and kept OUT of the content snapshot, so they never perturb the
     #     `updated`/drift logic. See DATA_DICTIONARY.md for the confidence rule.
     for e in deduped:
+        e["tier"] = _derive_tier(e)
         e["source_count"] = len(e.get("source_ids") or [])
         e["confidence"] = _derive_confidence(e)
         e.setdefault("source_status", "active")

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -48,13 +48,13 @@ def is_out_of_scope_malware(entry: dict) -> bool:
 def _derive_tier(entry: dict) -> str:
     """Two-tier split (INCLUSION.md §5): the curated/notable LANDMARK set vs
     the comprehensive vulnerability/advisory FEED. landmark = hand-curated, a
-    real-world incident (AIID-linked), an AI-harm case, or a real-world-category
-    event; feed = the CVE/GHSA/OSV bulk. Headline claims should cite the
-    landmark count, not the raw total."""
+    real-world incident catalogued in the AI Incident Database (`aiid_id`), or
+    an AI-harm case; feed = the CVE/GHSA/OSV bulk. (The `real-world` *category*
+    is deliberately NOT used — it also tags exploited CVEs, which belong in the
+    feed.) Headline claims should cite the landmark count, not the raw total."""
     if (entry.get("quality_tier") == "curated"
             or entry.get("aiid_id")
-            or entry.get("corpus") == "ai-harm"
-            or entry.get("category") == "real-world"):
+            or entry.get("corpus") == "ai-harm"):
         return "landmark"
     return "feed"
 

--- a/scripts/render_markdown.py
+++ b/scripts/render_markdown.py
@@ -502,6 +502,7 @@ def render():
     years = sorted({e.get("year") for e in entries if e.get("year")})
     stats = {
         "incident_count": raw.get("incident_count", len(entries)),
+        "landmark_count": sum(1 for e in entries if e.get("tier") == "landmark"),
         "version": raw.get("version", ""),
         "generated": raw.get("generated", ""),
         "year_min": years[0] if years else None,

--- a/src/genai_incidents/schema/incident.schema.json
+++ b/src/genai_incidents/schema/incident.schema.json
@@ -109,6 +109,11 @@
       "description": "Transparent, rule-derived confidence in the entry (see DATA_DICTIONARY.md). high = curated/reviewed OR 2+ distinct sources with a CVE; medium = 2+ sources OR has a CVE/CVSS; low = a single auto-tier source.",
       "enum": ["high", "medium", "low"]
     },
+    "tier": {
+      "type": "string",
+      "description": "Curated/notable `landmark` incidents vs the comprehensive vulnerability/advisory `feed` (INCLUSION.md §5). landmark = curated, AIID-linked real-world, ai-harm, or real-world-category; feed = the CVE/GHSA/OSV bulk. Cite the landmark count for headlines.",
+      "enum": ["landmark", "feed"]
+    },
     "source_count": {
       "type": "integer",
       "description": "Number of distinct upstream sources (source_ids) corroborating the entry.",


### PR DESCRIPTION
First Pillar-2 deliverable. Makes explicit the distinction between the **curated/notable landmark incidents** and the **comprehensive vulnerability/advisory feed** — so headline claims cite the landmark set, not the raw total (the v2.3.0 lesson, structurally).

- **`tier` field** (derived, deterministic, out of content snapshot): `landmark` = curated OR AIID-linked real-world OR ai-harm; `feed` = the CVE/GHSA/OSV bulk. (The broad `real-world` *category* is deliberately excluded — sampling showed it inflated landmark to 6,215 by catching exploited CVEs.)
- **landmark = 1,837** / feed = 9,821. Sample landmark titles are genuinely notable (Morris II, many-shot jailbreaking, Slack AI injection, Crescendo, …).
- `stats.json` gains **`landmark_count`**; the site gains a **Tier filter**.
- Schema + DATA_DICTIONARY documented.

Verified in container: idempotent, validate + integrity clean, 11,658 total unchanged.