### PR TITLE
feat(coverage): CWE→CAPEC + PURL linkage graph (#30)

### DIFF
--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -46,6 +46,8 @@ Every incident in [`data/incidents.json`](../data/incidents.json) follows
 |---|---|---|
 | `cve_ids` | string[] | `CVE-YYYY-NNNN…`. |
 | `cwe_ids` | string[] | `CWE-NNN`. |
+| `capec_ids` | string[] | `CAPEC-NNN` attack patterns, **derived** from `cwe_ids` via the authoritative CWE→CAPEC map (`mappings/cwe_capec.json`, built by `scripts/build_cwe_capec.py` from MITRE's CAPEC corpus). The complete, uncapped union — a broad CWE legitimately implies many patterns — so high-CWE records carry many CAPECs by design. Fully reconstructable from `cwe_ids` + the map; denormalised here for convenience. |
+| `purl` | string[] | Package-URLs (`pkg:type/namespace/name`) **derived** from structured GHSA/OSV `affected` identifiers (e.g. `pip/foo` → `pkg:pypi/foo`, `maven/g:a` → `pkg:maven/g/a`). Entity-resolution anchor for the affected package; absent when `affected` is free-text. Only ecosystems with an official purl type are emitted. |
 | `cvss_score` | number | 0–10. |
 | `cvss_vector` | string | Full CVSS vector string. |
 | `aiid_id` | integer | AI Incident Database numeric id where cross-listed. |

--- a/mappings/cwe_capec.json
+++ b/mappings/cwe_capec.json
@@ -1,0 +1,1890 @@
+{
+  "_source": "MITRE CAPEC (Mechanisms of Attack view)",
+  "_capec_count": 615,
+  "cwe_to_capec": {
+    "CWE-6": [
+      "CAPEC-21",
+      "CAPEC-59"
+    ],
+    "CWE-15": [
+      "CAPEC-13",
+      "CAPEC-69",
+      "CAPEC-76",
+      "CAPEC-77",
+      "CAPEC-146",
+      "CAPEC-176",
+      "CAPEC-203",
+      "CAPEC-270",
+      "CAPEC-271",
+      "CAPEC-579"
+    ],
+    "CWE-20": [
+      "CAPEC-3",
+      "CAPEC-7",
+      "CAPEC-8",
+      "CAPEC-9",
+      "CAPEC-10",
+      "CAPEC-13",
+      "CAPEC-14",
+      "CAPEC-22",
+      "CAPEC-23",
+      "CAPEC-24",
+      "CAPEC-28",
+      "CAPEC-31",
+      "CAPEC-42",
+      "CAPEC-43",
+      "CAPEC-45",
+      "CAPEC-46",
+      "CAPEC-47",
+      "CAPEC-52",
+      "CAPEC-53",
+      "CAPEC-63",
+      "CAPEC-64",
+      "CAPEC-67",
+      "CAPEC-71",
+      "CAPEC-72",
+      "CAPEC-73",
+      "CAPEC-78",
+      "CAPEC-79",
+      "CAPEC-80",
+      "CAPEC-81",
+      "CAPEC-83",
+      "CAPEC-85",
+      "CAPEC-88",
+      "CAPEC-101",
+      "CAPEC-104",
+      "CAPEC-108",
+      "CAPEC-109",
+      "CAPEC-110",
+      "CAPEC-120",
+      "CAPEC-135",
+      "CAPEC-136",
+      "CAPEC-153",
+      "CAPEC-182",
+      "CAPEC-209",
+      "CAPEC-230",
+      "CAPEC-231",
+      "CAPEC-250",
+      "CAPEC-261",
+      "CAPEC-267",
+      "CAPEC-473",
+      "CAPEC-588",
+      "CAPEC-664"
+    ],
+    "CWE-22": [
+      "CAPEC-64",
+      "CAPEC-76",
+      "CAPEC-78",
+      "CAPEC-79",
+      "CAPEC-126"
+    ],
+    "CWE-23": [
+      "CAPEC-76",
+      "CAPEC-139"
+    ],
+    "CWE-36": [
+      "CAPEC-597"
+    ],
+    "CWE-41": [
+      "CAPEC-3"
+    ],
+    "CWE-46": [
+      "CAPEC-649"
+    ],
+    "CWE-59": [
+      "CAPEC-17",
+      "CAPEC-35",
+      "CAPEC-76",
+      "CAPEC-132"
+    ],
+    "CWE-61": [
+      "CAPEC-27"
+    ],
+    "CWE-69": [
+      "CAPEC-168"
+    ],
+    "CWE-73": [
+      "CAPEC-13",
+      "CAPEC-64",
+      "CAPEC-72",
+      "CAPEC-76",
+      "CAPEC-78",
+      "CAPEC-79",
+      "CAPEC-80",
+      "CAPEC-267"
+    ],
+    "CWE-74": [
+      "CAPEC-3",
+      "CAPEC-6",
+      "CAPEC-7",
+      "CAPEC-8",
+      "CAPEC-9",
+      "CAPEC-10",
+      "CAPEC-13",
+      "CAPEC-14",
+      "CAPEC-24",
+      "CAPEC-28",
+      "CAPEC-34",
+      "CAPEC-42",
+      "CAPEC-43",
+      "CAPEC-45",
+      "CAPEC-46",
+      "CAPEC-47",
+      "CAPEC-51",
+      "CAPEC-52",
+      "CAPEC-53",
+      "CAPEC-64",
+      "CAPEC-67",
+      "CAPEC-71",
+      "CAPEC-72",
+      "CAPEC-76",
+      "CAPEC-78",
+      "CAPEC-79",
+      "CAPEC-80",
+      "CAPEC-83",
+      "CAPEC-84",
+      "CAPEC-101",
+      "CAPEC-105",
+      "CAPEC-108",
+      "CAPEC-120",
+      "CAPEC-135",
+      "CAPEC-250",
+      "CAPEC-267",
+      "CAPEC-273"
+    ],
+    "CWE-75": [
+      "CAPEC-81",
+      "CAPEC-93"
+    ],
+    "CWE-77": [
+      "CAPEC-15",
+      "CAPEC-40",
+      "CAPEC-43",
+      "CAPEC-75",
+      "CAPEC-76",
+      "CAPEC-136",
+      "CAPEC-183",
+      "CAPEC-248"
+    ],
+    "CWE-78": [
+      "CAPEC-6",
+      "CAPEC-15",
+      "CAPEC-43",
+      "CAPEC-88",
+      "CAPEC-108"
+    ],
+    "CWE-79": [
+      "CAPEC-63",
+      "CAPEC-85",
+      "CAPEC-209",
+      "CAPEC-588",
+      "CAPEC-591",
+      "CAPEC-592"
+    ],
+    "CWE-80": [
+      "CAPEC-18",
+      "CAPEC-32",
+      "CAPEC-86",
+      "CAPEC-193"
+    ],
+    "CWE-81": [
+      "CAPEC-198"
+    ],
+    "CWE-83": [
+      "CAPEC-243",
+      "CAPEC-244",
+      "CAPEC-588"
+    ],
+    "CWE-85": [
+      "CAPEC-245"
+    ],
+    "CWE-86": [
+      "CAPEC-73",
+      "CAPEC-85",
+      "CAPEC-247"
+    ],
+    "CWE-87": [
+      "CAPEC-199"
+    ],
+    "CWE-88": [
+      "CAPEC-41",
+      "CAPEC-88",
+      "CAPEC-137",
+      "CAPEC-174",
+      "CAPEC-460"
+    ],
+    "CWE-89": [
+      "CAPEC-7",
+      "CAPEC-66",
+      "CAPEC-108",
+      "CAPEC-109",
+      "CAPEC-110",
+      "CAPEC-470"
+    ],
+    "CWE-90": [
+      "CAPEC-136"
+    ],
+    "CWE-91": [
+      "CAPEC-83",
+      "CAPEC-250"
+    ],
+    "CWE-93": [
+      "CAPEC-15",
+      "CAPEC-81"
+    ],
+    "CWE-94": [
+      "CAPEC-35",
+      "CAPEC-77",
+      "CAPEC-242"
+    ],
+    "CWE-95": [
+      "CAPEC-35"
+    ],
+    "CWE-96": [
+      "CAPEC-35",
+      "CAPEC-73",
+      "CAPEC-77",
+      "CAPEC-81",
+      "CAPEC-85"
+    ],
+    "CWE-97": [
+      "CAPEC-35",
+      "CAPEC-101"
+    ],
+    "CWE-98": [
+      "CAPEC-193"
+    ],
+    "CWE-99": [
+      "CAPEC-10",
+      "CAPEC-75",
+      "CAPEC-240"
+    ],
+    "CWE-112": [
+      "CAPEC-230",
+      "CAPEC-231"
+    ],
+    "CWE-113": [
+      "CAPEC-31",
+      "CAPEC-34",
+      "CAPEC-85",
+      "CAPEC-105"
+    ],
+    "CWE-114": [
+      "CAPEC-108",
+      "CAPEC-640"
+    ],
+    "CWE-116": [
+      "CAPEC-73",
+      "CAPEC-81",
+      "CAPEC-85",
+      "CAPEC-104"
+    ],
+    "CWE-117": [
+      "CAPEC-81",
+      "CAPEC-93",
+      "CAPEC-268"
+    ],
+    "CWE-118": [
+      "CAPEC-8",
+      "CAPEC-9",
+      "CAPEC-10",
+      "CAPEC-14",
+      "CAPEC-24",
+      "CAPEC-45",
+      "CAPEC-46",
+      "CAPEC-47"
+    ],
+    "CWE-119": [
+      "CAPEC-8",
+      "CAPEC-9",
+      "CAPEC-10",
+      "CAPEC-14",
+      "CAPEC-24",
+      "CAPEC-42",
+      "CAPEC-44",
+      "CAPEC-45",
+      "CAPEC-46",
+      "CAPEC-47",
+      "CAPEC-100",
+      "CAPEC-123"
+    ],
+    "CWE-120": [
+      "CAPEC-8",
+      "CAPEC-9",
+      "CAPEC-10",
+      "CAPEC-14",
+      "CAPEC-24",
+      "CAPEC-42",
+      "CAPEC-44",
+      "CAPEC-45",
+      "CAPEC-46",
+      "CAPEC-47",
+      "CAPEC-67",
+      "CAPEC-92",
+      "CAPEC-100"
+    ],
+    "CWE-122": [
+      "CAPEC-92"
+    ],
+    "CWE-125": [
+      "CAPEC-540"
+    ],
+    "CWE-128": [
+      "CAPEC-92"
+    ],
+    "CWE-129": [
+      "CAPEC-100"
+    ],
+    "CWE-130": [
+      "CAPEC-47"
+    ],
+    "CWE-131": [
+      "CAPEC-47",
+      "CAPEC-100"
+    ],
+    "CWE-134": [
+      "CAPEC-67",
+      "CAPEC-135"
+    ],
+    "CWE-138": [
+      "CAPEC-15",
+      "CAPEC-34",
+      "CAPEC-105"
+    ],
+    "CWE-140": [
+      "CAPEC-15"
+    ],
+    "CWE-146": [
+      "CAPEC-6",
+      "CAPEC-15"
+    ],
+    "CWE-147": [
+      "CAPEC-460"
+    ],
+    "CWE-149": [
+      "CAPEC-468"
+    ],
+    "CWE-150": [
+      "CAPEC-41",
+      "CAPEC-81",
+      "CAPEC-93",
+      "CAPEC-134"
+    ],
+    "CWE-154": [
+      "CAPEC-15"
+    ],
+    "CWE-157": [
+      "CAPEC-15"
+    ],
+    "CWE-158": [
+      "CAPEC-52",
+      "CAPEC-53"
+    ],
+    "CWE-162": [
+      "CAPEC-635"
+    ],
+    "CWE-172": [
+      "CAPEC-3",
+      "CAPEC-52",
+      "CAPEC-53",
+      "CAPEC-64",
+      "CAPEC-71",
+      "CAPEC-72",
+      "CAPEC-78",
+      "CAPEC-80",
+      "CAPEC-120",
+      "CAPEC-267"
+    ],
+    "CWE-173": [
+      "CAPEC-3",
+      "CAPEC-4",
+      "CAPEC-52",
+      "CAPEC-53",
+      "CAPEC-64",
+      "CAPEC-71",
+      "CAPEC-72",
+      "CAPEC-78",
+      "CAPEC-79",
+      "CAPEC-80",
+      "CAPEC-120",
+      "CAPEC-267"
+    ],
+    "CWE-176": [
+      "CAPEC-71"
+    ],
+    "CWE-177": [
+      "CAPEC-64",
+      "CAPEC-72",
+      "CAPEC-120",
+      "CAPEC-468"
+    ],
+    "CWE-179": [
+      "CAPEC-3",
+      "CAPEC-43",
+      "CAPEC-71"
+    ],
+    "CWE-180": [
+      "CAPEC-3",
+      "CAPEC-71",
+      "CAPEC-78",
+      "CAPEC-79",
+      "CAPEC-80",
+      "CAPEC-267"
+    ],
+    "CWE-181": [
+      "CAPEC-3",
+      "CAPEC-43",
+      "CAPEC-78",
+      "CAPEC-79",
+      "CAPEC-80",
+      "CAPEC-120",
+      "CAPEC-267"
+    ],
+    "CWE-183": [
+      "CAPEC-3",
+      "CAPEC-43",
+      "CAPEC-71",
+      "CAPEC-120"
+    ],
+    "CWE-184": [
+      "CAPEC-3",
+      "CAPEC-6",
+      "CAPEC-15",
+      "CAPEC-43",
+      "CAPEC-71",
+      "CAPEC-73",
+      "CAPEC-85",
+      "CAPEC-120",
+      "CAPEC-182"
+    ],
+    "CWE-185": [
+      "CAPEC-6",
+      "CAPEC-15",
+      "CAPEC-79"
+    ],
+    "CWE-190": [
+      "CAPEC-92"
+    ],
+    "CWE-196": [
+      "CAPEC-92"
+    ],
+    "CWE-200": [
+      "CAPEC-13",
+      "CAPEC-22",
+      "CAPEC-59",
+      "CAPEC-60",
+      "CAPEC-79",
+      "CAPEC-116",
+      "CAPEC-169",
+      "CAPEC-224",
+      "CAPEC-285",
+      "CAPEC-287",
+      "CAPEC-290",
+      "CAPEC-291",
+      "CAPEC-292",
+      "CAPEC-293",
+      "CAPEC-294",
+      "CAPEC-295",
+      "CAPEC-296",
+      "CAPEC-297",
+      "CAPEC-298",
+      "CAPEC-299",
+      "CAPEC-300",
+      "CAPEC-301",
+      "CAPEC-302",
+      "CAPEC-303",
+      "CAPEC-304",
+      "CAPEC-305",
+      "CAPEC-306",
+      "CAPEC-307",
+      "CAPEC-308",
+      "CAPEC-309",
+      "CAPEC-310",
+      "CAPEC-312",
+      "CAPEC-313",
+      "CAPEC-317",
+      "CAPEC-318",
+      "CAPEC-319",
+      "CAPEC-320",
+      "CAPEC-321",
+      "CAPEC-322",
+      "CAPEC-323",
+      "CAPEC-324",
+      "CAPEC-325",
+      "CAPEC-326",
+      "CAPEC-327",
+      "CAPEC-328",
+      "CAPEC-329",
+      "CAPEC-330",
+      "CAPEC-472",
+      "CAPEC-497",
+      "CAPEC-508",
+      "CAPEC-573",
+      "CAPEC-574",
+      "CAPEC-575",
+      "CAPEC-576",
+      "CAPEC-577",
+      "CAPEC-616",
+      "CAPEC-643",
+      "CAPEC-646",
+      "CAPEC-651"
+    ],
+    "CWE-201": [
+      "CAPEC-12",
+      "CAPEC-217",
+      "CAPEC-612",
+      "CAPEC-613",
+      "CAPEC-618",
+      "CAPEC-619",
+      "CAPEC-621",
+      "CAPEC-622",
+      "CAPEC-623"
+    ],
+    "CWE-203": [
+      "CAPEC-189"
+    ],
+    "CWE-204": [
+      "CAPEC-331",
+      "CAPEC-332",
+      "CAPEC-541",
+      "CAPEC-580"
+    ],
+    "CWE-205": [
+      "CAPEC-541",
+      "CAPEC-580"
+    ],
+    "CWE-208": [
+      "CAPEC-462",
+      "CAPEC-541",
+      "CAPEC-580"
+    ],
+    "CWE-209": [
+      "CAPEC-7",
+      "CAPEC-54",
+      "CAPEC-215",
+      "CAPEC-463"
+    ],
+    "CWE-212": [
+      "CAPEC-168"
+    ],
+    "CWE-221": [
+      "CAPEC-81"
+    ],
+    "CWE-226": [
+      "CAPEC-37"
+    ],
+    "CWE-233": [
+      "CAPEC-39"
+    ],
+    "CWE-235": [
+      "CAPEC-460"
+    ],
+    "CWE-241": [
+      "CAPEC-48"
+    ],
+    "CWE-250": [
+      "CAPEC-69",
+      "CAPEC-104",
+      "CAPEC-470"
+    ],
+    "CWE-257": [
+      "CAPEC-49"
+    ],
+    "CWE-261": [
+      "CAPEC-55"
+    ],
+    "CWE-262": [
+      "CAPEC-16",
+      "CAPEC-49",
+      "CAPEC-55",
+      "CAPEC-70",
+      "CAPEC-509",
+      "CAPEC-555",
+      "CAPEC-560",
+      "CAPEC-561",
+      "CAPEC-565",
+      "CAPEC-600",
+      "CAPEC-652",
+      "CAPEC-653"
+    ],
+    "CWE-263": [
+      "CAPEC-16",
+      "CAPEC-49",
+      "CAPEC-55",
+      "CAPEC-70",
+      "CAPEC-509",
+      "CAPEC-555",
+      "CAPEC-560",
+      "CAPEC-561",
+      "CAPEC-565",
+      "CAPEC-600",
+      "CAPEC-652",
+      "CAPEC-653"
+    ],
+    "CWE-267": [
+      "CAPEC-58",
+      "CAPEC-634",
+      "CAPEC-637",
+      "CAPEC-643",
+      "CAPEC-648"
+    ],
+    "CWE-269": [
+      "CAPEC-58",
+      "CAPEC-122",
+      "CAPEC-233"
+    ],
+    "CWE-270": [
+      "CAPEC-17",
+      "CAPEC-30",
+      "CAPEC-35"
+    ],
+    "CWE-272": [
+      "CAPEC-17",
+      "CAPEC-35",
+      "CAPEC-76"
+    ],
+    "CWE-276": [
+      "CAPEC-1",
+      "CAPEC-81",
+      "CAPEC-127"
+    ],
+    "CWE-279": [
+      "CAPEC-81"
+    ],
+    "CWE-282": [
+      "CAPEC-17",
+      "CAPEC-35"
+    ],
+    "CWE-284": [
+      "CAPEC-19",
+      "CAPEC-441",
+      "CAPEC-478",
+      "CAPEC-479",
+      "CAPEC-502",
+      "CAPEC-503",
+      "CAPEC-536",
+      "CAPEC-546",
+      "CAPEC-550",
+      "CAPEC-551",
+      "CAPEC-552",
+      "CAPEC-556",
+      "CAPEC-558",
+      "CAPEC-562",
+      "CAPEC-563",
+      "CAPEC-564",
+      "CAPEC-578"
+    ],
+    "CWE-285": [
+      "CAPEC-1",
+      "CAPEC-5",
+      "CAPEC-13",
+      "CAPEC-17",
+      "CAPEC-39",
+      "CAPEC-45",
+      "CAPEC-51",
+      "CAPEC-59",
+      "CAPEC-60",
+      "CAPEC-76",
+      "CAPEC-77",
+      "CAPEC-87",
+      "CAPEC-104",
+      "CAPEC-127",
+      "CAPEC-402",
+      "CAPEC-647",
+      "CAPEC-668"
+    ],
+    "CWE-287": [
+      "CAPEC-22",
+      "CAPEC-57",
+      "CAPEC-94",
+      "CAPEC-114",
+      "CAPEC-115",
+      "CAPEC-151",
+      "CAPEC-194",
+      "CAPEC-593",
+      "CAPEC-633",
+      "CAPEC-650"
+    ],
+    "CWE-288": [
+      "CAPEC-127",
+      "CAPEC-665"
+    ],
+    "CWE-290": [
+      "CAPEC-21",
+      "CAPEC-22",
+      "CAPEC-59",
+      "CAPEC-60",
+      "CAPEC-94",
+      "CAPEC-459",
+      "CAPEC-461",
+      "CAPEC-473",
+      "CAPEC-476",
+      "CAPEC-667"
+    ],
+    "CWE-291": [
+      "CAPEC-4"
+    ],
+    "CWE-294": [
+      "CAPEC-60",
+      "CAPEC-94",
+      "CAPEC-102",
+      "CAPEC-509",
+      "CAPEC-555",
+      "CAPEC-561",
+      "CAPEC-644",
+      "CAPEC-645",
+      "CAPEC-652",
+      "CAPEC-701"
+    ],
+    "CWE-295": [
+      "CAPEC-459",
+      "CAPEC-475"
+    ],
+    "CWE-300": [
+      "CAPEC-57",
+      "CAPEC-94",
+      "CAPEC-466",
+      "CAPEC-589",
+      "CAPEC-590",
+      "CAPEC-612",
+      "CAPEC-613",
+      "CAPEC-615",
+      "CAPEC-662"
+    ],
+    "CWE-301": [
+      "CAPEC-90"
+    ],
+    "CWE-302": [
+      "CAPEC-10",
+      "CAPEC-13",
+      "CAPEC-21",
+      "CAPEC-31",
+      "CAPEC-39",
+      "CAPEC-45",
+      "CAPEC-77",
+      "CAPEC-274"
+    ],
+    "CWE-303": [
+      "CAPEC-90"
+    ],
+    "CWE-306": [
+      "CAPEC-12",
+      "CAPEC-36",
+      "CAPEC-62",
+      "CAPEC-166",
+      "CAPEC-216"
+    ],
+    "CWE-307": [
+      "CAPEC-16",
+      "CAPEC-49",
+      "CAPEC-560",
+      "CAPEC-565",
+      "CAPEC-600",
+      "CAPEC-652",
+      "CAPEC-653"
+    ],
+    "CWE-308": [
+      "CAPEC-16",
+      "CAPEC-49",
+      "CAPEC-55",
+      "CAPEC-70",
+      "CAPEC-509",
+      "CAPEC-555",
+      "CAPEC-560",
+      "CAPEC-561",
+      "CAPEC-565",
+      "CAPEC-600",
+      "CAPEC-644",
+      "CAPEC-645",
+      "CAPEC-652",
+      "CAPEC-653"
+    ],
+    "CWE-309": [
+      "CAPEC-16",
+      "CAPEC-49",
+      "CAPEC-55",
+      "CAPEC-70",
+      "CAPEC-509",
+      "CAPEC-555",
+      "CAPEC-560",
+      "CAPEC-561",
+      "CAPEC-565",
+      "CAPEC-600",
+      "CAPEC-652",
+      "CAPEC-653"
+    ],
+    "CWE-311": [
+      "CAPEC-31",
+      "CAPEC-37",
+      "CAPEC-65",
+      "CAPEC-157",
+      "CAPEC-158",
+      "CAPEC-204",
+      "CAPEC-383",
+      "CAPEC-384",
+      "CAPEC-385",
+      "CAPEC-386",
+      "CAPEC-387",
+      "CAPEC-388",
+      "CAPEC-477",
+      "CAPEC-609"
+    ],
+    "CWE-312": [
+      "CAPEC-37"
+    ],
+    "CWE-314": [
+      "CAPEC-37"
+    ],
+    "CWE-315": [
+      "CAPEC-31",
+      "CAPEC-37",
+      "CAPEC-39",
+      "CAPEC-74"
+    ],
+    "CWE-318": [
+      "CAPEC-37",
+      "CAPEC-65"
+    ],
+    "CWE-319": [
+      "CAPEC-65",
+      "CAPEC-102",
+      "CAPEC-117",
+      "CAPEC-383",
+      "CAPEC-477"
+    ],
+    "CWE-325": [
+      "CAPEC-68"
+    ],
+    "CWE-326": [
+      "CAPEC-20",
+      "CAPEC-112",
+      "CAPEC-192"
+    ],
+    "CWE-327": [
+      "CAPEC-20",
+      "CAPEC-97",
+      "CAPEC-459",
+      "CAPEC-473",
+      "CAPEC-475",
+      "CAPEC-608",
+      "CAPEC-614"
+    ],
+    "CWE-328": [
+      "CAPEC-68",
+      "CAPEC-461"
+    ],
+    "CWE-330": [
+      "CAPEC-59",
+      "CAPEC-112",
+      "CAPEC-485"
+    ],
+    "CWE-331": [
+      "CAPEC-59"
+    ],
+    "CWE-345": [
+      "CAPEC-111",
+      "CAPEC-141",
+      "CAPEC-142",
+      "CAPEC-148",
+      "CAPEC-218",
+      "CAPEC-384",
+      "CAPEC-385",
+      "CAPEC-386",
+      "CAPEC-387",
+      "CAPEC-388",
+      "CAPEC-665",
+      "CAPEC-701"
+    ],
+    "CWE-346": [
+      "CAPEC-21",
+      "CAPEC-59",
+      "CAPEC-60",
+      "CAPEC-75",
+      "CAPEC-76",
+      "CAPEC-89",
+      "CAPEC-111",
+      "CAPEC-141",
+      "CAPEC-142",
+      "CAPEC-160",
+      "CAPEC-384",
+      "CAPEC-385",
+      "CAPEC-386",
+      "CAPEC-387",
+      "CAPEC-388",
+      "CAPEC-510"
+    ],
+    "CWE-347": [
+      "CAPEC-463",
+      "CAPEC-475"
+    ],
+    "CWE-348": [
+      "CAPEC-73",
+      "CAPEC-76",
+      "CAPEC-85",
+      "CAPEC-141",
+      "CAPEC-142"
+    ],
+    "CWE-349": [
+      "CAPEC-75",
+      "CAPEC-141",
+      "CAPEC-142"
+    ],
+    "CWE-350": [
+      "CAPEC-73",
+      "CAPEC-89",
+      "CAPEC-142",
+      "CAPEC-275"
+    ],
+    "CWE-352": [
+      "CAPEC-62",
+      "CAPEC-111",
+      "CAPEC-462",
+      "CAPEC-467"
+    ],
+    "CWE-353": [
+      "CAPEC-13",
+      "CAPEC-14",
+      "CAPEC-39",
+      "CAPEC-74",
+      "CAPEC-75",
+      "CAPEC-389",
+      "CAPEC-665"
+    ],
+    "CWE-354": [
+      "CAPEC-75",
+      "CAPEC-145",
+      "CAPEC-463"
+    ],
+    "CWE-359": [
+      "CAPEC-464",
+      "CAPEC-467",
+      "CAPEC-498",
+      "CAPEC-508"
+    ],
+    "CWE-362": [
+      "CAPEC-26",
+      "CAPEC-29"
+    ],
+    "CWE-363": [
+      "CAPEC-26"
+    ],
+    "CWE-366": [
+      "CAPEC-26",
+      "CAPEC-29"
+    ],
+    "CWE-367": [
+      "CAPEC-27",
+      "CAPEC-29"
+    ],
+    "CWE-368": [
+      "CAPEC-26",
+      "CAPEC-29"
+    ],
+    "CWE-370": [
+      "CAPEC-26",
+      "CAPEC-29"
+    ],
+    "CWE-372": [
+      "CAPEC-74",
+      "CAPEC-140"
+    ],
+    "CWE-377": [
+      "CAPEC-149",
+      "CAPEC-155"
+    ],
+    "CWE-384": [
+      "CAPEC-21",
+      "CAPEC-31",
+      "CAPEC-39",
+      "CAPEC-59",
+      "CAPEC-60",
+      "CAPEC-61",
+      "CAPEC-196"
+    ],
+    "CWE-385": [
+      "CAPEC-462"
+    ],
+    "CWE-400": [
+      "CAPEC-147",
+      "CAPEC-227",
+      "CAPEC-492"
+    ],
+    "CWE-404": [
+      "CAPEC-125",
+      "CAPEC-130",
+      "CAPEC-131",
+      "CAPEC-494",
+      "CAPEC-495",
+      "CAPEC-496",
+      "CAPEC-666"
+    ],
+    "CWE-412": [
+      "CAPEC-25"
+    ],
+    "CWE-419": [
+      "CAPEC-383"
+    ],
+    "CWE-424": [
+      "CAPEC-127",
+      "CAPEC-554"
+    ],
+    "CWE-425": [
+      "CAPEC-87",
+      "CAPEC-127",
+      "CAPEC-143",
+      "CAPEC-144",
+      "CAPEC-668"
+    ],
+    "CWE-426": [
+      "CAPEC-38"
+    ],
+    "CWE-427": [
+      "CAPEC-38",
+      "CAPEC-471"
+    ],
+    "CWE-430": [
+      "CAPEC-11"
+    ],
+    "CWE-434": [
+      "CAPEC-1"
+    ],
+    "CWE-436": [
+      "CAPEC-34",
+      "CAPEC-105",
+      "CAPEC-273"
+    ],
+    "CWE-441": [
+      "CAPEC-219",
+      "CAPEC-465"
+    ],
+    "CWE-444": [
+      "CAPEC-33",
+      "CAPEC-273"
+    ],
+    "CWE-451": [
+      "CAPEC-98",
+      "CAPEC-154",
+      "CAPEC-163",
+      "CAPEC-164",
+      "CAPEC-173"
+    ],
+    "CWE-470": [
+      "CAPEC-138"
+    ],
+    "CWE-471": [
+      "CAPEC-384",
+      "CAPEC-385",
+      "CAPEC-386",
+      "CAPEC-387",
+      "CAPEC-388"
+    ],
+    "CWE-472": [
+      "CAPEC-31",
+      "CAPEC-39",
+      "CAPEC-146",
+      "CAPEC-226"
+    ],
+    "CWE-473": [
+      "CAPEC-77"
+    ],
+    "CWE-488": [
+      "CAPEC-59",
+      "CAPEC-60"
+    ],
+    "CWE-489": [
+      "CAPEC-121",
+      "CAPEC-661"
+    ],
+    "CWE-494": [
+      "CAPEC-184",
+      "CAPEC-185",
+      "CAPEC-186",
+      "CAPEC-187",
+      "CAPEC-533",
+      "CAPEC-538",
+      "CAPEC-657",
+      "CAPEC-662",
+      "CAPEC-691",
+      "CAPEC-692",
+      "CAPEC-693",
+      "CAPEC-695"
+    ],
+    "CWE-497": [
+      "CAPEC-170",
+      "CAPEC-694"
+    ],
+    "CWE-502": [
+      "CAPEC-586"
+    ],
+    "CWE-506": [
+      "CAPEC-442",
+      "CAPEC-448",
+      "CAPEC-636"
+    ],
+    "CWE-507": [
+      "CAPEC-698"
+    ],
+    "CWE-514": [
+      "CAPEC-463"
+    ],
+    "CWE-521": [
+      "CAPEC-16",
+      "CAPEC-49",
+      "CAPEC-55",
+      "CAPEC-70",
+      "CAPEC-112",
+      "CAPEC-509",
+      "CAPEC-555",
+      "CAPEC-561",
+      "CAPEC-565"
+    ],
+    "CWE-522": [
+      "CAPEC-50",
+      "CAPEC-102",
+      "CAPEC-474",
+      "CAPEC-509",
+      "CAPEC-551",
+      "CAPEC-555",
+      "CAPEC-560",
+      "CAPEC-561",
+      "CAPEC-600",
+      "CAPEC-644",
+      "CAPEC-645",
+      "CAPEC-652",
+      "CAPEC-653"
+    ],
+    "CWE-523": [
+      "CAPEC-102"
+    ],
+    "CWE-524": [
+      "CAPEC-204"
+    ],
+    "CWE-525": [
+      "CAPEC-37"
+    ],
+    "CWE-532": [
+      "CAPEC-215"
+    ],
+    "CWE-538": [
+      "CAPEC-95"
+    ],
+    "CWE-539": [
+      "CAPEC-21",
+      "CAPEC-31",
+      "CAPEC-39",
+      "CAPEC-59",
+      "CAPEC-60"
+    ],
+    "CWE-552": [
+      "CAPEC-150",
+      "CAPEC-639"
+    ],
+    "CWE-553": [
+      "CAPEC-650"
+    ],
+    "CWE-564": [
+      "CAPEC-109"
+    ],
+    "CWE-565": [
+      "CAPEC-31",
+      "CAPEC-39",
+      "CAPEC-226"
+    ],
+    "CWE-567": [
+      "CAPEC-25"
+    ],
+    "CWE-589": [
+      "CAPEC-96"
+    ],
+    "CWE-593": [
+      "CAPEC-94"
+    ],
+    "CWE-601": [
+      "CAPEC-178"
+    ],
+    "CWE-602": [
+      "CAPEC-21",
+      "CAPEC-31",
+      "CAPEC-162",
+      "CAPEC-202",
+      "CAPEC-207",
+      "CAPEC-208",
+      "CAPEC-383",
+      "CAPEC-384",
+      "CAPEC-385",
+      "CAPEC-386",
+      "CAPEC-387",
+      "CAPEC-388"
+    ],
+    "CWE-610": [
+      "CAPEC-219"
+    ],
+    "CWE-611": [
+      "CAPEC-221"
+    ],
+    "CWE-614": [
+      "CAPEC-102"
+    ],
+    "CWE-638": [
+      "CAPEC-104"
+    ],
+    "CWE-640": [
+      "CAPEC-50"
+    ],
+    "CWE-642": [
+      "CAPEC-21",
+      "CAPEC-31"
+    ],
+    "CWE-645": [
+      "CAPEC-2"
+    ],
+    "CWE-646": [
+      "CAPEC-209"
+    ],
+    "CWE-648": [
+      "CAPEC-107",
+      "CAPEC-234"
+    ],
+    "CWE-649": [
+      "CAPEC-463"
+    ],
+    "CWE-654": [
+      "CAPEC-16",
+      "CAPEC-49",
+      "CAPEC-55",
+      "CAPEC-70",
+      "CAPEC-274",
+      "CAPEC-560",
+      "CAPEC-565",
+      "CAPEC-600",
+      "CAPEC-652",
+      "CAPEC-653"
+    ],
+    "CWE-662": [
+      "CAPEC-25",
+      "CAPEC-26",
+      "CAPEC-27",
+      "CAPEC-29"
+    ],
+    "CWE-663": [
+      "CAPEC-29"
+    ],
+    "CWE-664": [
+      "CAPEC-21",
+      "CAPEC-60",
+      "CAPEC-61",
+      "CAPEC-62",
+      "CAPEC-196"
+    ],
+    "CWE-665": [
+      "CAPEC-26",
+      "CAPEC-29"
+    ],
+    "CWE-667": [
+      "CAPEC-25",
+      "CAPEC-26",
+      "CAPEC-27"
+    ],
+    "CWE-674": [
+      "CAPEC-230",
+      "CAPEC-231"
+    ],
+    "CWE-680": [
+      "CAPEC-8",
+      "CAPEC-9",
+      "CAPEC-10",
+      "CAPEC-14",
+      "CAPEC-24",
+      "CAPEC-45",
+      "CAPEC-46",
+      "CAPEC-47",
+      "CAPEC-67",
+      "CAPEC-92",
+      "CAPEC-100"
+    ],
+    "CWE-682": [
+      "CAPEC-128",
+      "CAPEC-129"
+    ],
+    "CWE-689": [
+      "CAPEC-26",
+      "CAPEC-27"
+    ],
+    "CWE-691": [
+      "CAPEC-29"
+    ],
+    "CWE-692": [
+      "CAPEC-71",
+      "CAPEC-80",
+      "CAPEC-85",
+      "CAPEC-120",
+      "CAPEC-267"
+    ],
+    "CWE-693": [
+      "CAPEC-1",
+      "CAPEC-17",
+      "CAPEC-20",
+      "CAPEC-22",
+      "CAPEC-36",
+      "CAPEC-51",
+      "CAPEC-57",
+      "CAPEC-59",
+      "CAPEC-65",
+      "CAPEC-74",
+      "CAPEC-87",
+      "CAPEC-107",
+      "CAPEC-127",
+      "CAPEC-237",
+      "CAPEC-477",
+      "CAPEC-480",
+      "CAPEC-668"
+    ],
+    "CWE-695": [
+      "CAPEC-36"
+    ],
+    "CWE-696": [
+      "CAPEC-463"
+    ],
+    "CWE-697": [
+      "CAPEC-3",
+      "CAPEC-6",
+      "CAPEC-7",
+      "CAPEC-8",
+      "CAPEC-9",
+      "CAPEC-10",
+      "CAPEC-14",
+      "CAPEC-15",
+      "CAPEC-24",
+      "CAPEC-41",
+      "CAPEC-43",
+      "CAPEC-44",
+      "CAPEC-45",
+      "CAPEC-46",
+      "CAPEC-47",
+      "CAPEC-52",
+      "CAPEC-53",
+      "CAPEC-64",
+      "CAPEC-67",
+      "CAPEC-71",
+      "CAPEC-73",
+      "CAPEC-78",
+      "CAPEC-79",
+      "CAPEC-80",
+      "CAPEC-88",
+      "CAPEC-92",
+      "CAPEC-120",
+      "CAPEC-182",
+      "CAPEC-267"
+    ],
+    "CWE-706": [
+      "CAPEC-48",
+      "CAPEC-159",
+      "CAPEC-177",
+      "CAPEC-641"
+    ],
+    "CWE-707": [
+      "CAPEC-3",
+      "CAPEC-7",
+      "CAPEC-43",
+      "CAPEC-52",
+      "CAPEC-53",
+      "CAPEC-64",
+      "CAPEC-78",
+      "CAPEC-79",
+      "CAPEC-83",
+      "CAPEC-84",
+      "CAPEC-250",
+      "CAPEC-276",
+      "CAPEC-277",
+      "CAPEC-278",
+      "CAPEC-279",
+      "CAPEC-468"
+    ],
+    "CWE-732": [
+      "CAPEC-1",
+      "CAPEC-17",
+      "CAPEC-60",
+      "CAPEC-61",
+      "CAPEC-62",
+      "CAPEC-122",
+      "CAPEC-127",
+      "CAPEC-180",
+      "CAPEC-206",
+      "CAPEC-234",
+      "CAPEC-642"
+    ],
+    "CWE-733": [
+      "CAPEC-8",
+      "CAPEC-9",
+      "CAPEC-10",
+      "CAPEC-24",
+      "CAPEC-46"
+    ],
+    "CWE-749": [
+      "CAPEC-500"
+    ],
+    "CWE-757": [
+      "CAPEC-220",
+      "CAPEC-606",
+      "CAPEC-620"
+    ],
+    "CWE-770": [
+      "CAPEC-125",
+      "CAPEC-130",
+      "CAPEC-147",
+      "CAPEC-197",
+      "CAPEC-229",
+      "CAPEC-230",
+      "CAPEC-231",
+      "CAPEC-469",
+      "CAPEC-482",
+      "CAPEC-486",
+      "CAPEC-487",
+      "CAPEC-488",
+      "CAPEC-489",
+      "CAPEC-490",
+      "CAPEC-491",
+      "CAPEC-493",
+      "CAPEC-494",
+      "CAPEC-495",
+      "CAPEC-496",
+      "CAPEC-528"
+    ],
+    "CWE-772": [
+      "CAPEC-469"
+    ],
+    "CWE-776": [
+      "CAPEC-197"
+    ],
+    "CWE-798": [
+      "CAPEC-70",
+      "CAPEC-191"
+    ],
+    "CWE-805": [
+      "CAPEC-100",
+      "CAPEC-256"
+    ],
+    "CWE-822": [
+      "CAPEC-129"
+    ],
+    "CWE-823": [
+      "CAPEC-129"
+    ],
+    "CWE-829": [
+      "CAPEC-175",
+      "CAPEC-201",
+      "CAPEC-228",
+      "CAPEC-251",
+      "CAPEC-252",
+      "CAPEC-253",
+      "CAPEC-263",
+      "CAPEC-538",
+      "CAPEC-549",
+      "CAPEC-640",
+      "CAPEC-660",
+      "CAPEC-695",
+      "CAPEC-698"
+    ],
+    "CWE-833": [
+      "CAPEC-25"
+    ],
+    "CWE-836": [
+      "CAPEC-644",
+      "CAPEC-652"
+    ],
+    "CWE-838": [
+      "CAPEC-468"
+    ],
+    "CWE-862": [
+      "CAPEC-665"
+    ],
+    "CWE-912": [
+      "CAPEC-133",
+      "CAPEC-190"
+    ],
+    "CWE-916": [
+      "CAPEC-55"
+    ],
+    "CWE-918": [
+      "CAPEC-664"
+    ],
+    "CWE-923": [
+      "CAPEC-161",
+      "CAPEC-481",
+      "CAPEC-501",
+      "CAPEC-697"
+    ],
+    "CWE-925": [
+      "CAPEC-499"
+    ],
+    "CWE-940": [
+      "CAPEC-500",
+      "CAPEC-594",
+      "CAPEC-595",
+      "CAPEC-596"
+    ],
+    "CWE-943": [
+      "CAPEC-676"
+    ],
+    "CWE-1007": [
+      "CAPEC-632"
+    ],
+    "CWE-1021": [
+      "CAPEC-103",
+      "CAPEC-181",
+      "CAPEC-222",
+      "CAPEC-504",
+      "CAPEC-506",
+      "CAPEC-587",
+      "CAPEC-654"
+    ],
+    "CWE-1037": [
+      "CAPEC-663"
+    ],
+    "CWE-1188": [
+      "CAPEC-665"
+    ],
+    "CWE-1189": [
+      "CAPEC-124"
+    ],
+    "CWE-1190": [
+      "CAPEC-180"
+    ],
+    "CWE-1191": [
+      "CAPEC-1",
+      "CAPEC-180"
+    ],
+    "CWE-1192": [
+      "CAPEC-113"
+    ],
+    "CWE-1193": [
+      "CAPEC-1",
+      "CAPEC-180"
+    ],
+    "CWE-1204": [
+      "CAPEC-20",
+      "CAPEC-97"
+    ],
+    "CWE-1209": [
+      "CAPEC-121"
+    ],
+    "CWE-1220": [
+      "CAPEC-1",
+      "CAPEC-180"
+    ],
+    "CWE-1221": [
+      "CAPEC-166"
+    ],
+    "CWE-1222": [
+      "CAPEC-679"
+    ],
+    "CWE-1223": [
+      "CAPEC-26"
+    ],
+    "CWE-1224": [
+      "CAPEC-680"
+    ],
+    "CWE-1231": [
+      "CAPEC-680"
+    ],
+    "CWE-1232": [
+      "CAPEC-166"
+    ],
+    "CWE-1233": [
+      "CAPEC-176",
+      "CAPEC-680"
+    ],
+    "CWE-1234": [
+      "CAPEC-176"
+    ],
+    "CWE-1239": [
+      "CAPEC-37",
+      "CAPEC-150",
+      "CAPEC-204",
+      "CAPEC-545"
+    ],
+    "CWE-1240": [
+      "CAPEC-97"
+    ],
+    "CWE-1241": [
+      "CAPEC-97"
+    ],
+    "CWE-1242": [
+      "CAPEC-36",
+      "CAPEC-212"
+    ],
+    "CWE-1243": [
+      "CAPEC-116",
+      "CAPEC-545"
+    ],
+    "CWE-1244": [
+      "CAPEC-114"
+    ],
+    "CWE-1245": [
+      "CAPEC-74"
+    ],
+    "CWE-1246": [
+      "CAPEC-212"
+    ],
+    "CWE-1247": [
+      "CAPEC-624",
+      "CAPEC-625"
+    ],
+    "CWE-1248": [
+      "CAPEC-624",
+      "CAPEC-625"
+    ],
+    "CWE-1252": [
+      "CAPEC-679"
+    ],
+    "CWE-1253": [
+      "CAPEC-74"
+    ],
+    "CWE-1254": [
+      "CAPEC-26"
+    ],
+    "CWE-1255": [
+      "CAPEC-189"
+    ],
+    "CWE-1256": [
+      "CAPEC-624",
+      "CAPEC-625"
+    ],
+    "CWE-1257": [
+      "CAPEC-456",
+      "CAPEC-679"
+    ],
+    "CWE-1258": [
+      "CAPEC-37",
+      "CAPEC-150",
+      "CAPEC-204",
+      "CAPEC-545"
+    ],
+    "CWE-1259": [
+      "CAPEC-121",
+      "CAPEC-681"
+    ],
+    "CWE-1260": [
+      "CAPEC-456",
+      "CAPEC-679"
+    ],
+    "CWE-1262": [
+      "CAPEC-680"
+    ],
+    "CWE-1263": [
+      "CAPEC-401"
+    ],
+    "CWE-1264": [
+      "CAPEC-233",
+      "CAPEC-663"
+    ],
+    "CWE-1265": [
+      "CAPEC-74"
+    ],
+    "CWE-1266": [
+      "CAPEC-37",
+      "CAPEC-150",
+      "CAPEC-545",
+      "CAPEC-546",
+      "CAPEC-675"
+    ],
+    "CWE-1267": [
+      "CAPEC-121",
+      "CAPEC-681"
+    ],
+    "CWE-1268": [
+      "CAPEC-180"
+    ],
+    "CWE-1269": [
+      "CAPEC-439"
+    ],
+    "CWE-1270": [
+      "CAPEC-121",
+      "CAPEC-633",
+      "CAPEC-681"
+    ],
+    "CWE-1271": [
+      "CAPEC-74"
+    ],
+    "CWE-1272": [
+      "CAPEC-37",
+      "CAPEC-150",
+      "CAPEC-545",
+      "CAPEC-546"
+    ],
+    "CWE-1273": [
+      "CAPEC-560"
+    ],
+    "CWE-1274": [
+      "CAPEC-456",
+      "CAPEC-679"
+    ],
+    "CWE-1275": [
+      "CAPEC-62"
+    ],
+    "CWE-1277": [
+      "CAPEC-682"
+    ],
+    "CWE-1278": [
+      "CAPEC-37",
+      "CAPEC-188",
+      "CAPEC-545"
+    ],
+    "CWE-1279": [
+      "CAPEC-97"
+    ],
+    "CWE-1280": [
+      "CAPEC-180"
+    ],
+    "CWE-1281": [
+      "CAPEC-212"
+    ],
+    "CWE-1282": [
+      "CAPEC-458",
+      "CAPEC-679"
+    ],
+    "CWE-1283": [
+      "CAPEC-680"
+    ],
+    "CWE-1286": [
+      "CAPEC-66",
+      "CAPEC-676"
+    ],
+    "CWE-1294": [
+      "CAPEC-121",
+      "CAPEC-681"
+    ],
+    "CWE-1295": [
+      "CAPEC-121"
+    ],
+    "CWE-1296": [
+      "CAPEC-121",
+      "CAPEC-702"
+    ],
+    "CWE-1297": [
+      "CAPEC-1",
+      "CAPEC-180"
+    ],
+    "CWE-1298": [
+      "CAPEC-26"
+    ],
+    "CWE-1299": [
+      "CAPEC-457",
+      "CAPEC-554"
+    ],
+    "CWE-1300": [
+      "CAPEC-189",
+      "CAPEC-699"
+    ],
+    "CWE-1301": [
+      "CAPEC-37"
+    ],
+    "CWE-1302": [
+      "CAPEC-121",
+      "CAPEC-681"
+    ],
+    "CWE-1303": [
+      "CAPEC-663"
+    ],
+    "CWE-1304": [
+      "CAPEC-176"
+    ],
+    "CWE-1310": [
+      "CAPEC-682"
+    ],
+    "CWE-1311": [
+      "CAPEC-1",
+      "CAPEC-180",
+      "CAPEC-233"
+    ],
+    "CWE-1312": [
+      "CAPEC-456",
+      "CAPEC-679"
+    ],
+    "CWE-1313": [
+      "CAPEC-121"
+    ],
+    "CWE-1314": [
+      "CAPEC-1"
+    ],
+    "CWE-1315": [
+      "CAPEC-1",
+      "CAPEC-180"
+    ],
+    "CWE-1316": [
+      "CAPEC-456",
+      "CAPEC-679"
+    ],
+    "CWE-1317": [
+      "CAPEC-122"
+    ],
+    "CWE-1318": [
+      "CAPEC-1",
+      "CAPEC-180"
+    ],
+    "CWE-1319": [
+      "CAPEC-624",
+      "CAPEC-625"
+    ],
+    "CWE-1320": [
+      "CAPEC-1",
+      "CAPEC-180"
+    ],
+    "CWE-1321": [
+      "CAPEC-1",
+      "CAPEC-77",
+      "CAPEC-180"
+    ],
+    "CWE-1322": [
+      "CAPEC-25"
+    ],
+    "CWE-1323": [
+      "CAPEC-150",
+      "CAPEC-167",
+      "CAPEC-545"
+    ],
+    "CWE-1325": [
+      "CAPEC-130"
+    ],
+    "CWE-1326": [
+      "CAPEC-68",
+      "CAPEC-679"
+    ],
+    "CWE-1327": [
+      "CAPEC-1"
+    ],
+    "CWE-1328": [
+      "CAPEC-176"
+    ],
+    "CWE-1330": [
+      "CAPEC-37",
+      "CAPEC-150",
+      "CAPEC-545"
+    ],
+    "CWE-1331": [
+      "CAPEC-124"
+    ],
+    "CWE-1332": [
+      "CAPEC-624",
+      "CAPEC-625"
+    ],
+    "CWE-1333": [
+      "CAPEC-492"
+    ],
+    "CWE-1334": [
+      "CAPEC-624",
+      "CAPEC-625"
+    ],
+    "CWE-1338": [
+      "CAPEC-624",
+      "CAPEC-625"
+    ],
+    "CWE-1342": [
+      "CAPEC-696"
+    ],
+    "CWE-1351": [
+      "CAPEC-624",
+      "CAPEC-625"
+    ]
+  }
+}

--- a/schema/incident.schema.json
+++ b/schema/incident.schema.json
@@ -27,6 +27,18 @@
       "items": { "type": "string", "pattern": "^CWE-[0-9]{1,4}$" },
       "uniqueItems": true
     },
+    "capec_ids": {
+      "type": "array",
+      "description": "MITRE CAPEC attack-pattern identifiers, derived from the entry's CWEs via the authoritative CWE->CAPEC map (mappings/cwe_capec.json). A complete (uncapped) denormalisation — see DATA_DICTIONARY.md.",
+      "items": { "type": "string", "pattern": "^CAPEC-[0-9]{1,4}$" },
+      "uniqueItems": true
+    },
+    "purl": {
+      "type": "array",
+      "description": "Package-URLs (purl, pkg:type/namespace/name) derived from structured GHSA/OSV `affected` identifiers — entity-resolution anchors for affected packages. See DATA_DICTIONARY.md.",
+      "items": { "type": "string", "pattern": "^pkg:[a-z]+/.+" },
+      "uniqueItems": true
+    },
     "cvss_score": {
       "type": "number",
       "minimum": 0,

--- a/scripts/build_cwe_capec.py
+++ b/scripts/build_cwe_capec.py
@@ -1,0 +1,61 @@
+"""
+build_cwe_capec.py
+==================
+
+Build an authoritative CWE -> CAPEC mapping from MITRE's CAPEC corpus and write
+it to mappings/cwe_capec.json. Each CAPEC entry lists its Related Weaknesses
+(CWE ids); we invert that to CWE -> sorted list of CAPEC ids.
+
+Committed and refreshed deliberately (CAPEC changes rarely), so the build stays
+deterministic — merge_and_dedupe reads the committed map, never the live feed.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+import urllib.request
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / "mappings" / "cwe_capec.json"
+CAPEC_CSV_ZIP = "https://capec.mitre.org/data/csv/2000.csv.zip"  # "Mechanisms of Attack" view (all)
+
+
+def main() -> None:
+    print(f"[capec] fetching {CAPEC_CSV_ZIP}", flush=True)
+    raw = urllib.request.urlopen(CAPEC_CSV_ZIP, timeout=90).read()
+    z = zipfile.ZipFile(io.BytesIO(raw))
+    txt = z.read(z.namelist()[0]).decode("utf-8", "replace")
+    rdr = csv.DictReader(io.StringIO(txt))
+    # The id column name can carry a BOM/quotes; find it robustly.
+    id_col = next((c for c in rdr.fieldnames if c.strip().strip("'\"").upper() == "ID"),
+                  rdr.fieldnames[0])
+
+    cwe_to_capec: dict[str, set[str]] = {}
+    n_capec = 0
+    for row in rdr:
+        capec_id = (row.get(id_col) or "").strip()
+        if not capec_id.isdigit():
+            continue
+        n_capec += 1
+        related = row.get("Related Weaknesses") or ""
+        for cwe_num in re.findall(r"(\d+)", related):
+            cwe_to_capec.setdefault(f"CWE-{cwe_num}", set()).add(f"CAPEC-{capec_id}")
+
+    mapping = {cwe: sorted(caps, key=lambda c: int(c.split("-")[1]))
+               for cwe, caps in sorted(cwe_to_capec.items(),
+                                       key=lambda kv: int(kv[0].split("-")[1]))}
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(
+        {"_source": "MITRE CAPEC (Mechanisms of Attack view)",
+         "_capec_count": n_capec, "cwe_to_capec": mapping},
+        indent=2) + "\n", encoding="utf-8")
+    print(f"[capec] {n_capec} CAPECs -> {len(mapping)} CWEs mapped -> {OUT}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -45,6 +45,87 @@ def is_out_of_scope_malware(entry: dict) -> bool:
     return not any(package_is_strongly_ai(p) for p in pkgs)
 
 
+_CWE_CAPEC_PATH = Path(__file__).resolve().parents[1] / "mappings" / "cwe_capec.json"
+
+# GHSA ecosystem token -> Package-URL (purl) type. Only ecosystems with an
+# official purl `type` are mapped; anything else (e.g. GitHub Actions) yields
+# no purl rather than an invented identifier.
+_ECO_TO_PURL = {
+    "pip": "pypi", "npm": "npm", "go": "golang", "composer": "composer",
+    "maven": "maven", "nuget": "nuget", "rust": "cargo", "rubygems": "gem",
+    "swift": "swift", "pub": "pub", "erlang": "hex",
+}
+# A structured `affected` fragment looks like "<ecosystem>/<package[/subpath]>"
+# (the GHSA ecosystem/name form). The package part may itself contain slashes
+# (Go module paths) and a trailing version expression we strip.
+_PKG_RE = re.compile(r"^([a-z][a-z0-9+.\-]*)/(.+)$")
+
+
+def _load_cwe_capec() -> dict[str, list[str]]:
+    """Authoritative CWE -> [CAPEC, ...] map (mappings/cwe_capec.json, built by
+    scripts/build_cwe_capec.py from MITRE's CAPEC corpus). Reading the committed
+    map keeps the build deterministic. Returns {} if absent."""
+    try:
+        raw = json.loads(_CWE_CAPEC_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return raw.get("cwe_to_capec", {}) if isinstance(raw, dict) else {}
+
+
+def _derive_capec_ids(entry: dict, cwe_capec: dict[str, list[str]]) -> list[str]:
+    """Complete CAPEC set implied by the entry's CWEs, via the authoritative
+    CWE->CAPEC map. The union is faithful (not capped): a record tagged with a
+    broad CWE legitimately relates to many attack patterns. Fully reconstructable
+    from `cwe_ids` + mappings/cwe_capec.json — it is a denormalised convenience,
+    documented in DATA_DICTIONARY.md."""
+    if not cwe_capec:
+        return []
+    caps: set[str] = set()
+    for c in entry.get("cwe_ids") or []:
+        caps.update(cwe_capec.get(c, ()))
+    return sorted(caps, key=lambda c: int(c.split("-")[1]))
+
+
+def _affected_to_purl(fragment: str) -> str | None:
+    """Convert one GHSA-style "<ecosystem>/<package>" fragment to a purl, or
+    None if the ecosystem has no official purl type or the fragment isn't the
+    structured form."""
+    m = _PKG_RE.match(fragment.strip())
+    if not m:
+        return None
+    ptype = _ECO_TO_PURL.get(m.group(1).lower())
+    if not ptype:
+        return None
+    # Drop any trailing version expression ("foo < 1.2", "foo <= 1.2.1").
+    name = re.split(r"\s+[<>=]", m.group(2).strip())[0].strip()
+    if not name:
+        return None
+    if ptype == "maven" and ":" in name:  # group:artifact -> group/artifact
+        ns, _, art = name.partition(":")
+        name = f"{ns}/{art}"
+    if ptype == "npm" and name.startswith("@"):  # scoped pkg: @scope -> %40scope
+        scope, _, pkg = name[1:].partition("/")
+        if pkg:
+            name = f"%40{scope}/{pkg}"
+    return f"pkg:{ptype}/{name}"
+
+
+def _derive_purls(entry: dict) -> list[str]:
+    """Package-URLs for an entry whose `affected` carries structured
+    "<ecosystem>/<package>" identifiers (the GHSA/OSV form). Comma-separated
+    fragments are each resolved; free-text `affected` (a product sentence) yields
+    nothing. Deterministic entity-resolution anchor (INCLUSION.md coverage)."""
+    aff = (entry.get("affected") or "").strip()
+    if not aff:
+        return []
+    out: set[str] = set()
+    for frag in aff.split(","):
+        p = _affected_to_purl(frag)
+        if p:
+            out.add(p)
+    return sorted(out)
+
+
 def _derive_tier(entry: dict) -> str:
     """Two-tier split (INCLUSION.md §5): the curated/notable LANDMARK set vs
     the comprehensive vulnerability/advisory FEED. landmark = hand-curated, a
@@ -1258,6 +1339,8 @@ def main():
     #     derivations of already-finalised fields — set AFTER history stamping
     #     and kept OUT of the content snapshot, so they never perturb the
     #     `updated`/drift logic. See DATA_DICTIONARY.md for the confidence rule.
+    cwe_capec = _load_cwe_capec()
+    n_capec = n_purl = 0
     for e in deduped:
         e["tier"] = _derive_tier(e)
         e["source_count"] = len(e.get("source_ids") or [])
@@ -1267,6 +1350,19 @@ def main():
             e["first_seen"] = e["added"]
         if e.get("updated"):
             e["last_seen"] = e["updated"]
+        # Linkage graph (INCLUSION.md coverage layer). Derived denormalisations
+        # of cwe_ids/affected; like the other provenance fields they are set
+        # here, AFTER history stamping, and kept OUT of the content snapshot so
+        # they never perturb the `updated`/drift logic.
+        capec = _derive_capec_ids(e, cwe_capec)
+        if capec:
+            e["capec_ids"] = capec
+            n_capec += 1
+        purl = _derive_purls(e)
+        if purl:
+            e["purl"] = purl
+            n_purl += 1
+    print(f"[linkage] capec_ids on {n_capec} entr(ies); purl on {n_purl} entr(ies)")
 
     print(f"\n[total]  {len(all_entries)} input -> {len(deduped)} unique")
 

--- a/src/genai_incidents/schema/incident.schema.json
+++ b/src/genai_incidents/schema/incident.schema.json
@@ -27,6 +27,18 @@
       "items": { "type": "string", "pattern": "^CWE-[0-9]{1,4}$" },
       "uniqueItems": true
     },
+    "capec_ids": {
+      "type": "array",
+      "description": "MITRE CAPEC attack-pattern identifiers, derived from the entry's CWEs via the authoritative CWE->CAPEC map (mappings/cwe_capec.json). A complete (uncapped) denormalisation — see DATA_DICTIONARY.md.",
+      "items": { "type": "string", "pattern": "^CAPEC-[0-9]{1,4}$" },
+      "uniqueItems": true
+    },
+    "purl": {
+      "type": "array",
+      "description": "Package-URLs (purl, pkg:type/namespace/name) derived from structured GHSA/OSV `affected` identifiers — entity-resolution anchors for affected packages. See DATA_DICTIONARY.md.",
+      "items": { "type": "string", "pattern": "^pkg:[a-z]+/.+" },
+      "uniqueItems": true
+    },
     "cvss_score": {
       "type": "number",
       "minimum": 0,


### PR DESCRIPTION
Closes #30 (P2 linkage graph).

## What
Two derived **linkage fields** on every incident, turning the dataset into a traversable graph (incident → CWE → CAPEC; incident → package PURL):

- **`capec_ids`** — MITRE CAPEC attack patterns, the complete (uncapped) union implied by the entry's `cwe_ids` via an authoritative **CWE→CAPEC** map. On **4,433** entries.
- **`purl`** — Package-URLs from structured GHSA/OSV `affected` identifiers (`pip/foo`→`pkg:pypi/foo`, `maven/g:a`→`pkg:maven/g/a`, scoped npm `%40`-encoded). Entity-resolution anchor for affected packages. On **3,620** entries.

## How
- New `scripts/build_cwe_capec.py` builds `mappings/cwe_capec.json` from MITRE's CAPEC corpus (committed for determinism — merge reads the map, never the live feed). 336 CWEs mapped, covering 177 of the dataset's CWEs.
- Fields derived in the provenance pass (step 6g) **after** dedup/history stamping and kept **out** of the content snapshot, so they never perturb the drift check.
- Full `data/incidents.json` only; slim site payload (`incidents.min.json`) unchanged.

## Rigor
- **Composition unchanged:** 0 added / 0 removed / 0 existing entries changed except the two new fields (vs `main`).
- **Idempotent:** build1 == build2 in a CI-parity Linux container.
- **Valid:** 11,658/11,658 schema-valid; no duplicate CVE/source keys; all deprecations resolve.
- Schema + `DATA_DICTIONARY.md` document both fields; faithful (uncapped) and fully reconstructable from `cwe_ids`/`affected` + the committed map.