### PR TITLE
release: v2.5.0 — linkage graph + MISP/TAXII integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ The dataset uses [SemVer](https://semver.org/) — major bumps for breaking
 schema or ID changes, minor bumps for additive schema fields or large
 ingest expansions, patch bumps for routine refreshes and bug fixes.
 
+## [2.5.0] — 2026-06-11
+
+### Added (Coverage — linkage graph, #30)
+- **`capec_ids`** on every CWE-bearing entry — MITRE CAPEC attack patterns
+  derived from `cwe_ids` via an authoritative CWE→CAPEC map
+  (`mappings/cwe_capec.json`, built by `scripts/build_cwe_capec.py` from MITRE's
+  CAPEC corpus). The complete, uncapped union; ~4,433 entries.
+- **`purl`** on every entry with a structured `affected` identifier — Package-URLs
+  (`pkg:type/namespace/name`) for entity resolution of affected packages
+  (`pip/foo`→`pkg:pypi/foo`, `maven/g:a`→`pkg:maven/g/a`, scoped npm `%40`-encoded);
+  ~3,620 entries.
+
+### Added (Adoption — integrations, #33)
+- **Static TAXII 2.1 endpoint** at `docs/taxii2/` (discovery, API root,
+  collections, objects + manifest envelopes) — a read-only mirror of the STIX
+  collection, generated at Pages deploy. `make taxii`.
+- **MISP feed** at `docs/misp/` (manifest + one Event per year + `hashes.csv`)
+  with `genai-incidents:*` / `mitre-atlas:technique` attribute tags. Subscribe a
+  MISP instance to the feed URL. `make misp`.
+
+### Notes
+- Schema gains `capec_ids` + `purl` (additive). Both fields are derived in the
+  provenance pass, kept out of the content snapshot, and added to the full
+  `data/incidents.json` only (the slim site payload is unchanged). Incident
+  composition is identical to v2.4.0 (0 added / 0 removed).
+
 ## [2.4.0] — 2026-06-11
 
 ### Added (Trust foundation)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,8 +33,8 @@ abstract: >-
   Framework (AI 100-1), and MITRE ATLAS. Aggregated from AIID, OECD AIM,
   AIAAIC, MITRE ATLAS, AVID, MIT FutureTech AI Risk Navigator, NVD/GHSA/OSV,
   garak, promptfoo, and dozens of researcher blogs and vendor threat reports.
-version: "2.4.0"
-date-released: "2026-06-10"
+version: "2.5.0"
+date-released: "2026-06-11"
 preferred-citation:
   type: dataset
   title: "GenAI & Agentic AI Security Incidents"

--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -3,7 +3,7 @@
 Single source of truth for GenAI and agentic AI security incidents.
 Each entry is mapped to **OWASP LLM Top 10 (2025)**, **OWASP Agentic Top 10 (ASI)**, **NIST AI RMF**, and **MITRE ATLAS**.
 
-- **Version:** 2.4.0
+- **Version:** 2.5.0
 - **Generated:** 2026-06-10
 - **Total incidents:** **11,658**
 - **Date range:** 1983 – 2026

--- a/data/incidents.min.json
+++ b/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.0",
+  "version": "2.5.0",
   "generated": "2026-06-10",
   "incident_count": 11658,
   "incidents": [

--- a/data/stats.json
+++ b/data/stats.json
@@ -1,7 +1,7 @@
 {
   "incident_count": 11658,
   "landmark_count": 1837,
-  "version": "2.4.0",
+  "version": "2.5.0",
   "generated": "2026-06-10",
   "year_min": 1983,
   "year_max": 2026

--- a/docs/data/incidents.min.json
+++ b/docs/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.0",
+  "version": "2.5.0",
   "generated": "2026-06-10",
   "incident_count": 11658,
   "incidents": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genai-incidents"
-version = "2.4.0"
+version = "2.5.0"
 description = "Curated dataset of GenAI & agentic-AI security incidents mapped to OWASP LLM Top 10, OWASP Agentic Top 10, NIST AI RMF, and MITRE ATLAS."
 readme = "README.md"
 license = "MIT"

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -1412,7 +1412,7 @@ def main():
 
     # 9) Write outputs
     out = {
-        "version": "2.4.0",
+        "version": "2.5.0",
         "generated": generated,
         "description": (
             "Single source of truth for GenAI and agentic AI security incidents. "

--- a/src/genai_incidents/data/incidents.min.json
+++ b/src/genai_incidents/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4.0",
+  "version": "2.5.0",
   "generated": "2026-06-10",
   "incident_count": 11658,
   "incidents": [


### PR DESCRIPTION
Cuts **v2.5.0**, shipping the two heaviest "world's best dataset" items.

## What's in it
- **#30 Linkage graph:** `capec_ids` (MITRE CAPEC via authoritative CWE→CAPEC map; 4,433 entries) + `purl` (Package-URLs from structured `affected`; 3,620 entries).
- **#33 Integrations:** static **TAXII 2.1** endpoint + **MISP feed**, generated at Pages deploy.

## Release mechanics
- Version bumped across `pyproject.toml`, `CITATION.cff` (+ date-released 2026-06-11), `merge_and_dedupe.py` data version string, and `CHANGELOG`.
- Data rebuilt in CI-parity Linux container: **version 2.5.0, 11,658 incidents, 0 added / 0 removed vs main, idempotent, schema-valid, integrity-clean.**
- Additive schema only; slim site payload unchanged.

Merging triggers `gh release create v2.5.0` → PyPI + Hugging Face auto-publish, Zenodo mints a new version DOI.