### PR TITLE
fix: correct stale '12,000+' incident count to honest '11,500+'

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - 📄 **Methodology:** [`docs/paper/genai-incidents-methods.md`](docs/paper/genai-incidents-methods.md) — how the dataset is built, mapped, and governed
 - 📜 **Changelog:** [`CHANGELOG.md`](CHANGELOG.md)
 
-A single source of truth of **[12,000+ GenAI and agentic AI security incidents](https://emmanuelgjr.github.io/genai_incidents/)** (see the live count in the badge above), each mapped to:
+A single source of truth of **[11,500+ GenAI and agentic AI security incidents](https://emmanuelgjr.github.io/genai_incidents/)** (see the live count in the badge above), each mapped to:
 
 - **OWASP Top 10 for LLM Applications (2025)** — `LLM01`–`LLM10`
 - **OWASP Agentic Top 10 (ASI)** — `ASI01`–`ASI10`

--- a/docs/app.js
+++ b/docs/app.js
@@ -184,7 +184,7 @@ function comparator() {
 
 function renderStats(allRows) {
   const total = allRows.length;
-  // Replace the static "12,000+" hero fallback with the exact live count.
+  // Replace the static "11,500+" hero fallback with the exact live count.
   const heroCount = document.getElementById('hero-count');
   if (heroCount) heroCount.textContent = fmtNum(total);
   const crit = allRows.filter(r => r.severity === 'Critical').length;

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,14 +21,14 @@
   <!-- Open Graph / Twitter — rich link previews when shared -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="GenAI &amp; Agentic AI Security Incidents">
-  <meta property="og:description" content="12,000+ GenAI &amp; agentic-AI security incidents, mapped to OWASP LLM Top 10, OWASP Agentic, NIST AI RMF &amp; MITRE ATLAS. Searchable, filterable, open data (CC-BY-4.0).">
+  <meta property="og:description" content="11,500+ GenAI &amp; agentic-AI security incidents, mapped to OWASP LLM Top 10, OWASP Agentic, NIST AI RMF &amp; MITRE ATLAS. Searchable, filterable, open data (CC-BY-4.0).">
   <meta property="og:url" content="https://emmanuelgjr.github.io/genai_incidents/">
   <meta property="og:image" content="https://emmanuelgjr.github.io/genai_incidents/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="GenAI &amp; Agentic AI Security Incidents">
-  <meta name="twitter:description" content="12,000+ GenAI &amp; agentic-AI security incidents, mapped to OWASP LLM Top 10, OWASP Agentic, NIST AI RMF &amp; MITRE ATLAS.">
+  <meta name="twitter:description" content="11,500+ GenAI &amp; agentic-AI security incidents, mapped to OWASP LLM Top 10, OWASP Agentic, NIST AI RMF &amp; MITRE ATLAS.">
   <meta name="twitter:image" content="https://emmanuelgjr.github.io/genai_incidents/og-image.png">
   <link rel="preload" href="data/incidents.min.json" as="fetch" type="application/json" crossorigin>
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -80,7 +80,7 @@
 
     <div class="cta-row">
       <a class="cta" href="#incidents-table">Browse the full table ↓</a>
-      <span class="cta-hint"><span id="hero-count">12,000+</span> entries, fully filterable. Charts below let you click any bar to drill in.</span>
+      <span class="cta-hint"><span id="hero-count">11,500+</span> entries, fully filterable. Charts below let you click any bar to drill in.</span>
     </div>
 
     <section class="charts-section" aria-label="trends">


### PR DESCRIPTION
The marketing count read **12,000+** but the dataset is **11,658** (it dropped from 12,062 in the v2.3.1 precision purge of generic-malware noise — *precision over volume*). That's an overclaim.

Replaces `12,000+` → `11,500+` (a true lower bound, durable against small fluctuations) in the only places it was hardcoded:
- `README.md` — "single source of truth" line
- `docs/index.html` — hero fallback + `og:description` + `twitter:description` (social cards)
- `docs/app.js` — the comment describing the fallback

Left untouched (verified via a full tracked-file audit): the live count **badge** (reads `stats.json`), the JS hero (sets the exact live count), the **OG image** (renders `incident_count` dynamically), `CHANGELOG`/release-note/spec **historical records**, generated `INCIDENTS.md` row-numbers, and internal "~12k"/"12k+" build-scaling code comments.

No data or composition change.