### PR TITLE
feat: add optional reversibility_class field for the landmark tier

### DIFF
--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -29,6 +29,7 @@ Every incident in [`data/incidents.json`](../data/incidents.json) follows
 | `attack_vector` | string | Controlled vocabulary (see schema `examples`): `prompt-injection`, `rce`, `data-exfiltration`, `deepfake`, `privacy-violation`, `algorithmic-bias`, `csam-generation`, `unsafe-advice`, `other`, … |
 | `affected` | string | Vendor / product / organization / system affected (free text). |
 | `impact` | string | Real-world consequence summary. |
+| `reversibility_class` | enum | Reversibility of the incident's **closing action**, ordered least→most severe: `read-only` → `reversible` → `external-reversible` → `irreversible` (see [TAXONOMIES.md](TAXONOMIES.md#reversibility-class), #74). Landmark-tier only, assigned via `data/curation_overrides.json` where source evidence describes the closing action (evidence + review date in the override `_note`). **Absence means unassessed, not `read-only`.** |
 
 ## Framework mappings
 | Field | Type | Notes |

--- a/docs/TAXONOMIES.md
+++ b/docs/TAXONOMIES.md
@@ -11,6 +11,7 @@ This dataset maps each incident to four (sometimes five) taxonomies. They don't 
 | What organizational risk function should respond? | **NIST AI RMF** |
 | What adversary tactic/technique was used? | **MITRE ATLAS** |
 | Where in the architecture did it originate / impact? | **MAESTRO** (companion) |
+| Does response get paged or queued — could the closing action be undone? | **Reversibility class** (landmark tier) |
 
 ---
 
@@ -126,6 +127,27 @@ Companion model that describes **where in the AI/agent architecture** an inciden
 | L7 | Human Factors & UX |
 
 The `role` field on a MAESTRO mapping indicates whether the layer was the `origin`, `impact`, `blind-spot`, `control`, `amplifier`, or `propagation` vector.
+
+---
+
+## Reversibility class
+
+Proposed in [#74](https://github.com/emmanuelgjr/genai_incidents/issues/74) (lineage: OWASP AISVS C09-02 reversibility-classification gating). Severity says how bad; `reversibility_class` says whether incident response gets **paged or queued** — the same attack vector routes very differently depending on what the closing action could undo.
+
+Four **ordered** classes, least → most severe:
+
+| Rank | Class | Meaning |
+|---|---|---|
+| 1 | `read-only` | No state mutation — the agent observed, read, summarized, or inferred but did not act on external systems. |
+| 2 | `reversible` | Mutation undoable in-session or by trivial in-system action (file recoverable from trash, internal-only draft). |
+| 3 | `external-reversible` | Mutation undoable only via an external compensating action (refund, retraction, correction outreach, manual cleanup). |
+| 4 | `irreversible` | No compensating action possible (unrecoverable deletion, funds transferred, content published and indexed). |
+
+Scope rules (precision-over-coverage):
+- **Landmark tier only** — enforced as a `validate.py` integrity invariant. `tier` is re-derived each build, so a labeled entry drifting out of the landmark set fails CI rather than shipping a stale judgment.
+- **Evidence-gated** — assigned via `data/curation_overrides.json` only where the source evidence describes the closing action, with evidence and review date in the override `_note`. Feed/auto entries stay empty rather than guessing.
+- **Absence means unassessed, not `read-only`.**
+- The JSON-schema enum carries no order — consumers must rank explicitly (alphabetical sorting puts `irreversible` between the two reversible classes).
 
 ---
 

--- a/schema/incident.schema.json
+++ b/schema/incident.schema.json
@@ -107,6 +107,11 @@
       "type": "string",
       "description": "Real-world consequence summary"
     },
+    "reversibility_class": {
+      "type": "string",
+      "description": "Reversibility of the action that closed the incident (#74), ordered least→most severe: read-only = no state mutation; reversible = undoable in-session or by trivial in-system action; external-reversible = undoable only via an external compensating action (refund, retraction, cleanup); irreversible = no compensating action possible. Landmark-tier only, assigned via data/curation_overrides.json where source evidence describes the closing action. Absent = unassessed, NOT read-only. The enum carries no lexical order — consumers must rank explicitly.",
+      "enum": ["read-only", "reversible", "external-reversible", "irreversible"]
+    },
     "severity": {
       "type": "string",
       "enum": ["Critical", "High", "Medium", "Low", "Info"]

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -936,7 +936,8 @@ def _load_prev_timestamps() -> dict[str, tuple[str, str, dict]]:
 # bumps the timestamp, but `added`/`updated` themselves obviously do not.
 _CONTENT_FIELDS = (
     "title", "date", "year", "category", "description", "attack_vector",
-    "affected", "impact", "severity", "owasp_llm", "owasp_asi", "owasp_dsgai",
+    "affected", "impact", "reversibility_class", "severity",
+    "owasp_llm", "owasp_asi", "owasp_dsgai",
     "nist_ai_rmf", "mitre_atlas", "mitre_atlas_tactics", "cve_ids", "cwe_ids",
     "cvss_score", "cvss_vector", "aiid_id", "disclosure_date",
     "exploited_in_wild", "kev_date_added",

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -50,6 +50,10 @@ def check_integrity(data: dict, deprecations: list[dict] | None = None) -> list[
     5.   Scope gate (INCLUSION.md): no out-of-scope malicious-package entry
          may survive — makes the v2.3.1 scope-purge a hard, enforced
          invariant so the generic-malware noise can never return.
+    6.   Reversibility gate (#74): `reversibility_class` is a landmark-tier,
+         evidence-gated label. `tier` is re-derived every build, so an entry
+         drifting out of the landmark set must fail loudly rather than ship
+         a stale editorial judgment on a feed record.
     """
     problems: list[str] = []
     incidents = data["incidents"]
@@ -82,6 +86,15 @@ def check_integrity(data: dict, deprecations: list[dict] | None = None) -> list[
                 f"{len(oos)} out-of-scope malicious-package entr(ies) survived the "
                 f"scope purge (e.g. {', '.join(oos[:5])})"
             )
+
+    # 6) Reversibility gate — labels only on the landmark tier.
+    mislabeled = [e["id"] for e in incidents
+                  if e.get("reversibility_class") and e.get("tier") != "landmark"]
+    if mislabeled:
+        problems.append(
+            f"{len(mislabeled)} entr(ies) carry reversibility_class outside the "
+            f"landmark tier (e.g. {', '.join(mislabeled[:5])})"
+        )
 
     if deprecations is not None:
         into_map = {d.get("from"): d.get("into") for d in deprecations}

--- a/src/genai_incidents/schema/incident.schema.json
+++ b/src/genai_incidents/schema/incident.schema.json
@@ -107,6 +107,11 @@
       "type": "string",
       "description": "Real-world consequence summary"
     },
+    "reversibility_class": {
+      "type": "string",
+      "description": "Reversibility of the action that closed the incident (#74), ordered least→most severe: read-only = no state mutation; reversible = undoable in-session or by trivial in-system action; external-reversible = undoable only via an external compensating action (refund, retraction, cleanup); irreversible = no compensating action possible. Landmark-tier only, assigned via data/curation_overrides.json where source evidence describes the closing action. Absent = unassessed, NOT read-only. The enum carries no lexical order — consumers must rank explicitly.",
+      "enum": ["read-only", "reversible", "external-reversible", "irreversible"]
+    },
     "severity": {
       "type": "string",
       "enum": ["Critical", "High", "Medium", "Low", "Info"]

--- a/tests/test_merge_and_dedupe.py
+++ b/tests/test_merge_and_dedupe.py
@@ -662,6 +662,12 @@ def test_kev_fields_are_content_fields():
     assert "kev_date_added" in m._CONTENT_FIELDS
 
 
+def test_reversibility_class_is_content_field():
+    # Labels land via curation_overrides.json (step 4d, before history
+    # stamping) and must bump `updated` exactly once — the KEV precedent.
+    assert "reversibility_class" in m._CONTENT_FIELDS
+
+
 # ---------------------------------------------------------------------------
 # Inclusion-policy scope purge (v2.3.1) — drop / don't-retain out-of-scope malware
 # ---------------------------------------------------------------------------

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -76,6 +76,21 @@ def test_integrity_evidence_gate_flags_sourceless():
     assert not any("primary source" in p for p in v.check_integrity(ok, []))
 
 
+def test_integrity_reversibility_gate_flags_non_landmark():
+    data = _data({"id": "INC-1", "tier": "feed",
+                  "reversibility_class": "irreversible"})
+    assert any("reversibility_class" in p for p in v.check_integrity(data, []))
+
+
+def test_integrity_reversibility_gate_allows_landmark():
+    data = _data({"id": "INC-1", "tier": "landmark",
+                  "reversibility_class": "read-only"})
+    assert not any("reversibility_class" in p for p in v.check_integrity(data, []))
+    # Unlabeled entries are fine on any tier — absence means unassessed.
+    unlabeled = _data({"id": "INC-2", "tier": "feed"})
+    assert not any("reversibility_class" in p for p in v.check_integrity(unlabeled, []))
+
+
 def test_integrity_scope_gate_flags_out_of_scope_malware():
     data = _data({"id": "INC-1", "tags": ["malicious-package"],
                   "affected": "npm/chai-mocks",


### PR DESCRIPTION
Implements the field proposed in #74 — schema, snapshot gating, integrity invariant, and docs only. No labels land in this PR; population is progressive via `data/curation_overrides.json`.

## What

- **`reversibility_class`** — optional enum on incident records: `read-only` | `reversible` | `external-reversible` | `irreversible`, classifying the reversibility of the action that closed the incident. Added to both schema copies (canonical + packaged, byte-identical).
- **Content-snapshot gating** — added to `_CONTENT_FIELDS` so a label applied via curation overrides bumps `updated` exactly once (the `exploited_in_wild`/`kev_date_added` precedent). Drift-safe: `_load_prev_state` recomputes prior snapshots with the current tuple, so the new key is `None == None` on every unlabeled record — no spurious `updated`/`generated` churn.
- **Integrity invariant (validate.py #6)** — `reversibility_class` may only appear on `tier=landmark` entries. `tier` is re-derived every build, so an entry drifting out of the landmark set fails CI rather than shipping a stale editorial judgment on a feed record.
- **Docs** — `DATA_DICTIONARY.md` row and a `TAXONOMIES.md` section defining the four ordered classes, the evidence gate (closing-action evidence + review date in the override `_note`), and two consumer warnings: **absence means unassessed, not `read-only`**, and the enum carries no lexical order (alphabetical sorting misorders it).

## Deliberate scope cuts (follow-ups, per one-focused-PR cadence)

- No population mechanism needed — overrides at merge step 4d already apply arbitrary content fields generically.
- Downstream threading is opt-in and untouched: STIX `x_*` whitelist, MISP `genai-incidents:*` tag, `incidents.min.json` slim projection / app.js filter / CSV column, package `query()` kwarg. The field is invisible on every surface until threaded.
- Known limitation for the labeling phase: overrides only apply to source-active entries; a new override targeting a `source_status=retained` entry no-ops silently.

## Verification

- `pytest tests -q` — 135 passed (3 new: content-field membership, landmark gate flags feed-tier labels, unlabeled entries pass on any tier).
- `scripts/validate.py` against committed data — 12,023/12,023 valid, integrity clean (additive change, nothing to migrate).
- `cmp` confirms the packaged schema copy is byte-identical.

Closes nothing on its own — #74 stays open to track label population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)