### PR TITLE
feat: VERIS 1.4.1 crosswalk — veris:* machinetags in the MISP feed

### DIFF
--- a/docs/TAXONOMIES.md
+++ b/docs/TAXONOMIES.md
@@ -157,7 +157,7 @@ Source: <https://github.com/vz-risk/veris> (VERIS 1.4.1 — the incident vocabul
 
 Not a per-incident schema field: a hand-curated crosswalk in [`mappings/veris.json`](../mappings/veris.json) from the controlled `attack_vector` vocabulary to VERIS enum paths, emitted as `veris:*` machinetags in the MISP feed (`scripts/export_misp.py`). Anchored on VERIS 1.4.1's GenAI enums (`action.hacking.variety` "Prompt injection", asset "S - LLM application"). It makes incidents legible to DBIR-contributor and risk-quantification consumers without adding schema surface.
 
-Curation rules: closest defensible enum only — values with no honest VERIS equivalent (`algorithmic-bias`, `other`) stay unmapped; the LLM-application asset tag is attached only to vectors that by definition target an LLM/agent app. Deliberately **not** derived by chaining ATLAS→ATT&CK→VERIS: only ~20% of ATLAS techniques have ATT&CK anchors, and none of the AI-native ones do.
+Curation rules: closest defensible enum only — values with no honest VERIS equivalent (`algorithmic-bias`, `adversarial-input`, `other`) stay unmapped; the LLM-application asset tag is attached only to vectors that by definition target an LLM/agent app. Deliberately **not** derived by chaining ATLAS→ATT&CK→VERIS: only ~20% of ATLAS techniques have ATT&CK anchors, and none of the AI-native ones do.
 
 **Use it when:** consuming the MISP feed alongside VERIS-coded corpora (DBIR, VCDB) or FAIR-style risk tooling. Note MISP's bundled `veris` taxonomy predates VERIS 1.4.1, so the AI-specific tags render as plain tags until upstream refreshes it.
 

--- a/docs/TAXONOMIES.md
+++ b/docs/TAXONOMIES.md
@@ -151,6 +151,18 @@ Scope rules (precision-over-coverage):
 
 ---
 
+## VERIS crosswalk (export-only)
+
+Source: <https://github.com/vz-risk/veris> (VERIS 1.4.1 — the incident vocabulary behind the Verizon DBIR and VCDB)
+
+Not a per-incident schema field: a hand-curated crosswalk in [`mappings/veris.json`](../mappings/veris.json) from the controlled `attack_vector` vocabulary to VERIS enum paths, emitted as `veris:*` machinetags in the MISP feed (`scripts/export_misp.py`). Anchored on VERIS 1.4.1's GenAI enums (`action.hacking.variety` "Prompt injection", asset "S - LLM application"). It makes incidents legible to DBIR-contributor and risk-quantification consumers without adding schema surface.
+
+Curation rules: closest defensible enum only — values with no honest VERIS equivalent (`algorithmic-bias`, `other`) stay unmapped; the LLM-application asset tag is attached only to vectors that by definition target an LLM/agent app. Deliberately **not** derived by chaining ATLAS→ATT&CK→VERIS: only ~20% of ATLAS techniques have ATT&CK anchors, and none of the AI-native ones do.
+
+**Use it when:** consuming the MISP feed alongside VERIS-coded corpora (DBIR, VCDB) or FAIR-style risk tooling. Note MISP's bundled `veris` taxonomy predates VERIS 1.4.1, so the AI-specific tags render as plain tags until upstream refreshes it.
+
+---
+
 ## How they map to each other
 
 The frameworks overlap deliberately. A single incident often hits **several** codes across taxonomies. Example: ShadowLeak (zero-click ChatGPT Deep Research data exfiltration).

--- a/mappings/veris.json
+++ b/mappings/veris.json
@@ -1,6 +1,6 @@
 {
   "_source": "VERIS Community Schema 1.4.1 (github.com/vz-risk/veris) — the incident vocabulary behind the Verizon DBIR and VCDB",
-  "_notes": "Hand-curated crosswalk from the controlled attack_vector vocabulary (schema/incident.schema.json examples) to VERIS enum paths, anchored on the 1.4.1 GenAI enums (action.hacking.variety 'Prompt injection', asset 'S - LLM application'). Entry format: '<misp-predicate>=<enum value>', where the predicate is the MISP veris-taxonomy machinetag predicate (colon-separated VERIS path); scripts/export_misp.py renders each as veris:<predicate>=\"<value>\". Values with no honest VERIS equivalent (algorithmic-bias, other) are deliberately unmapped — precision over coverage. The 'S - LLM application' asset row is attached only to vectors that by definition target an LLM/agent application, never inferred for generic web/infra vectors. Direct curation, NOT derived by chaining ATLAS->ATT&CK->VERIS (only ~20% of ATLAS techniques have ATT&CK anchors, and none of the AI-native ones).",
+  "_notes": "Hand-curated crosswalk from the controlled attack_vector vocabulary (schema/incident.schema.json examples) to VERIS enum paths, anchored on the 1.4.1 GenAI enums (action.hacking.variety 'Prompt injection', asset 'S - LLM application'). Entry format: '<misp-predicate>=<enum value>', where the predicate is the MISP veris-taxonomy machinetag predicate (colon-separated VERIS path); scripts/export_misp.py renders each as veris:<predicate>=\"<value>\". Curation rules: closest defensible enum per official VERIS definitions, adversarially reviewed against verisc-enum.json/verisc-labels.json. Values with no honest VERIS equivalent stay unmapped (algorithmic-bias, adversarial-input, other) — precision over coverage. jailbreak collapses into 'Prompt injection' (VERIS's definition — 'bypassing safety filters' — covers both; VERIS is deliberately that coarse). csam-generation keeps misuse 'Illicit content' with a caveat: VERIS misuse canonically covers trusted internal/partner actors, while GenAI illicit-content generation is usually an external user — kept because it is the only VERIS enum naming illicit content. The 'S - LLM application' asset row is attached only to vectors that by definition target an LLM/agent application, never inferred for generic web/infra vectors. Direct curation, NOT derived by chaining ATLAS->ATT&CK->VERIS (only ~20% of ATLAS techniques have ATT&CK anchors, and none of the AI-native ones).",
   "attack_vector_to_veris": {
     "prompt-injection": [
       "action:hacking:variety=Prompt injection",
@@ -11,7 +11,7 @@
       "asset:assets:variety=S - LLM application"
     ],
     "jailbreak": [
-      "action:hacking:variety=Evade Defenses",
+      "action:hacking:variety=Prompt injection",
       "asset:assets:variety=S - LLM application"
     ],
     "data-exfiltration": [
@@ -23,17 +23,18 @@
     ],
     "model-extraction": [
       "action:hacking:variety=Abuse of functionality",
+      "attribute:confidentiality:data_disclosure=Yes",
       "attribute:confidentiality:data:variety=Secrets"
     ],
     "model-poisoning": [
-      "attribute:integrity:variety=Alter behavior"
+      "attribute:integrity:variety=Modify data"
     ],
     "memory-poisoning": [
-      "attribute:integrity:variety=Alter behavior",
+      "attribute:integrity:variety=Modify data",
       "asset:assets:variety=S - LLM application"
     ],
     "supply-chain": [
-      "action:malware:vector=Software update"
+      "action:malware:vector=Partner"
     ],
     "rce": [
       "action:hacking:variety=Exploit vuln"
@@ -76,9 +77,6 @@
     "insider": [
       "action:misuse:variety=Privilege abuse"
     ],
-    "adversarial-input": [
-      "attribute:integrity:variety=Alter behavior"
-    ],
     "evasion": [
       "action:hacking:variety=Evade Defenses"
     ],
@@ -98,7 +96,7 @@
       "action:social:variety=Forgery"
     ],
     "misinformation": [
-      "action:social:variety=Influence"
+      "action:social:variety=Propaganda"
     ],
     "hallucination": [
       "action:error:variety=Misinformation"
@@ -107,7 +105,7 @@
       "action:social:variety=Phishing"
     ],
     "malware": [
-      "action:malware:variety=Trojan"
+      "action:malware:variety=Unknown"
     ],
     "backdoor": [
       "action:malware:variety=Backdoor"

--- a/mappings/veris.json
+++ b/mappings/veris.json
@@ -1,0 +1,126 @@
+{
+  "_source": "VERIS Community Schema 1.4.1 (github.com/vz-risk/veris) — the incident vocabulary behind the Verizon DBIR and VCDB",
+  "_notes": "Hand-curated crosswalk from the controlled attack_vector vocabulary (schema/incident.schema.json examples) to VERIS enum paths, anchored on the 1.4.1 GenAI enums (action.hacking.variety 'Prompt injection', asset 'S - LLM application'). Entry format: '<misp-predicate>=<enum value>', where the predicate is the MISP veris-taxonomy machinetag predicate (colon-separated VERIS path); scripts/export_misp.py renders each as veris:<predicate>=\"<value>\". Values with no honest VERIS equivalent (algorithmic-bias, other) are deliberately unmapped — precision over coverage. The 'S - LLM application' asset row is attached only to vectors that by definition target an LLM/agent application, never inferred for generic web/infra vectors. Direct curation, NOT derived by chaining ATLAS->ATT&CK->VERIS (only ~20% of ATLAS techniques have ATT&CK anchors, and none of the AI-native ones).",
+  "attack_vector_to_veris": {
+    "prompt-injection": [
+      "action:hacking:variety=Prompt injection",
+      "asset:assets:variety=S - LLM application"
+    ],
+    "indirect-prompt-injection": [
+      "action:hacking:variety=Prompt injection",
+      "asset:assets:variety=S - LLM application"
+    ],
+    "jailbreak": [
+      "action:hacking:variety=Evade Defenses",
+      "asset:assets:variety=S - LLM application"
+    ],
+    "data-exfiltration": [
+      "attribute:confidentiality:data_disclosure=Yes"
+    ],
+    "model-theft": [
+      "attribute:confidentiality:data_disclosure=Yes",
+      "attribute:confidentiality:data:variety=Secrets"
+    ],
+    "model-extraction": [
+      "action:hacking:variety=Abuse of functionality",
+      "attribute:confidentiality:data:variety=Secrets"
+    ],
+    "model-poisoning": [
+      "attribute:integrity:variety=Alter behavior"
+    ],
+    "memory-poisoning": [
+      "attribute:integrity:variety=Alter behavior",
+      "asset:assets:variety=S - LLM application"
+    ],
+    "supply-chain": [
+      "action:malware:vector=Software update"
+    ],
+    "rce": [
+      "action:hacking:variety=Exploit vuln"
+    ],
+    "ssrf": [
+      "action:hacking:variety=Exploit vuln"
+    ],
+    "deserialization": [
+      "action:hacking:variety=Insecure deserialization"
+    ],
+    "path-traversal": [
+      "action:hacking:variety=Path traversal"
+    ],
+    "sql-injection": [
+      "action:hacking:variety=SQLi"
+    ],
+    "command-injection": [
+      "action:hacking:variety=OS commanding"
+    ],
+    "xss": [
+      "action:hacking:variety=XSS"
+    ],
+    "auth-bypass": [
+      "action:hacking:variety=Exploit vuln"
+    ],
+    "sandbox-escape": [
+      "action:hacking:variety=User breakout"
+    ],
+    "info-disclosure": [
+      "attribute:confidentiality:data_disclosure=Yes"
+    ],
+    "tool-abuse": [
+      "action:hacking:variety=Abuse of functionality",
+      "asset:assets:variety=S - LLM application"
+    ],
+    "agent-hijack": [
+      "action:hacking:variety=Hijack",
+      "asset:assets:variety=S - LLM application"
+    ],
+    "insider": [
+      "action:misuse:variety=Privilege abuse"
+    ],
+    "adversarial-input": [
+      "attribute:integrity:variety=Alter behavior"
+    ],
+    "evasion": [
+      "action:hacking:variety=Evade Defenses"
+    ],
+    "membership-inference": [
+      "attribute:confidentiality:data_disclosure=Yes",
+      "attribute:confidentiality:data:variety=Personal"
+    ],
+    "model-inversion": [
+      "attribute:confidentiality:data_disclosure=Yes",
+      "attribute:confidentiality:data:variety=Personal"
+    ],
+    "dos": [
+      "action:hacking:variety=DoS",
+      "attribute:availability:variety=Interruption"
+    ],
+    "deepfake": [
+      "action:social:variety=Forgery"
+    ],
+    "misinformation": [
+      "action:social:variety=Influence"
+    ],
+    "hallucination": [
+      "action:error:variety=Misinformation"
+    ],
+    "phishing": [
+      "action:social:variety=Phishing"
+    ],
+    "malware": [
+      "action:malware:variety=Trojan"
+    ],
+    "backdoor": [
+      "action:malware:variety=Backdoor"
+    ],
+    "privacy-violation": [
+      "attribute:confidentiality:data_disclosure=Yes",
+      "attribute:confidentiality:data:variety=Personal"
+    ],
+    "csam-generation": [
+      "action:misuse:variety=Illicit content"
+    ],
+    "unsafe-advice": [
+      "action:error:variety=Misinformation"
+    ]
+  }
+}

--- a/scripts/export_misp.py
+++ b/scripts/export_misp.py
@@ -16,7 +16,9 @@ so they stay grouped, and carrying taxonomy as attribute Tags:
   - one ``link`` attribute per reference URL,
   - one ``text`` attribute holding the incident title,
 with Tags ``genai-incidents:*`` (incident id, attack vector, severity, OWASP
-LLM/ASI, corpus, tier) and ``mitre-atlas:technique="…"`` on the title attribute.
+LLM/ASI, corpus, tier), ``mitre-atlas:technique="…"``, and ``veris:*``
+machinetags (VERIS 1.4.1 enum paths derived from ``attack_vector`` via the
+hand-curated ``mappings/veris.json``) on the title attribute.
 
 Determinism: event/attribute UUIDs are UUIDv5 and every ``timestamp`` is derived
 from the year (fixed epoch), so the feed is byte-stable across rebuilds.
@@ -35,6 +37,16 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 DATA = ROOT / "data"
 OUT = ROOT / "docs" / "misp"
+
+# attack_vector -> VERIS 1.4.1 enum paths ("<misp-predicate>=<value>"),
+# hand-curated in mappings/veris.json. Missing file degrades to no veris tags
+# so the exporter stays runnable in isolation.
+try:
+    _VERIS_MAP: dict[str, list[str]] = json.loads(
+        (ROOT / "mappings" / "veris.json").read_text(encoding="utf-8")
+    ).get("attack_vector_to_veris", {})
+except (OSError, json.JSONDecodeError):
+    _VERIS_MAP = {}
 
 # Fixed namespace (shared scheme with the STIX export) so ids are stable.
 NS = uuid.UUID("6f1a9c4e-9b2d-5e7a-8c3f-0a1b2c3d4e5f")
@@ -75,6 +87,9 @@ def _incident_tags(e: dict) -> list[dict]:
         tags.append(_tag(f'genai-incidents:owasp-asi="{c}"'))
     for t in e.get("mitre_atlas") or []:
         tags.append(_tag(f'mitre-atlas:technique="{t}"'))
+    for mt in _VERIS_MAP.get(e.get("attack_vector") or "", []):
+        pred, _, val = mt.partition("=")
+        tags.append(_tag(f'veris:{pred}="{val}"'))
     return tags
 
 
@@ -198,7 +213,8 @@ A [MISP](https://www.misp-project.org/) feed mirroring the `genai_incidents`
 dataset, regenerated on every Pages deploy by `scripts/export_misp.py`.
 Incidents are grouped into **one Event per year** ({n_events} events); each
 incident's CVEs, reference links and title become tagged attributes
-(`genai-incidents:*`, `mitre-atlas:technique="…"`).
+(`genai-incidents:*`, `mitre-atlas:technique="…"`, and `veris:*` machinetags
+per the VERIS 1.4.1 crosswalk in `mappings/veris.json`).
 
 ## Subscribe (MISP)
 

--- a/tests/test_export_misp.py
+++ b/tests/test_export_misp.py
@@ -59,6 +59,46 @@ def test_incident_tags_and_attribute_types(tmp_path, monkeypatch):
     assert 'mitre-atlas:technique="AML.T0050"' in tagnames
 
 
+def test_veris_tags_from_attack_vector(tmp_path, monkeypatch):
+    out, _, _ = _build(tmp_path, monkeypatch)
+    events = [json.loads(p.read_text(encoding="utf-8"))["Event"]
+              for p in out.glob("*.json") if p.name != "manifest.json"]
+    attrs = [a for ev in events for a in ev["Attribute"]]
+    # INC-00001 (attack_vector=rce) carries the crosswalked VERIS machinetag.
+    title1 = next(a for a in attrs
+                  if a["type"] == "text" and a["comment"].startswith("INC-00001"))
+    assert 'veris:action:hacking:variety="Exploit vuln"' in {
+        t["name"] for t in title1["Tag"]}
+    # INC-00002 (attack_vector=other) is deliberately unmapped — no veris tags.
+    title2 = next(a for a in attrs
+                  if a["type"] == "text" and a["comment"].startswith("INC-00002"))
+    assert not any(t["name"].startswith("veris:") for t in title2["Tag"])
+
+
+def test_veris_mapping_file_is_well_formed():
+    # Every row: known attack_vector key, "predicate=value" entries with a
+    # colon-pathed predicate and a non-empty value, no stray quotes (values
+    # are interpolated into veris:<pred>="<value>" machinetags).
+    import re
+    from pathlib import Path
+    root = Path(m.__file__).resolve().parents[1]
+    mapping = json.loads((root / "mappings" / "veris.json").read_text(
+        encoding="utf-8"))["attack_vector_to_veris"]
+    schema = json.loads((root / "schema" / "incident.schema.json").read_text(
+        encoding="utf-8"))
+    known = set(schema["properties"]["attack_vector"]["examples"])
+    assert mapping, "empty mapping"
+    for av, entries in mapping.items():
+        assert av in known, f"unknown attack_vector key {av!r}"
+        assert entries, f"{av}: empty entry list"
+        for ent in entries:
+            pred, sep, val = ent.partition("=")
+            assert sep and val, f"{av}: malformed entry {ent!r}"
+            assert re.fullmatch(r"[a-z_]+(:[a-z_]+)*", pred), \
+                f"{av}: bad predicate {pred!r}"
+            assert '"' not in ent, f"{av}: quote in entry {ent!r}"
+
+
 def test_hashes_csv_covers_every_attribute(tmp_path, monkeypatch):
     out, _, n_attr = _build(tmp_path, monkeypatch)
     lines = [l for l in (out / "hashes.csv").read_text(encoding="utf-8").splitlines() if l]


### PR DESCRIPTION
First of the two VERIS adoptions from the vz-risk/veris evaluation (the data verdict was negative: VCDB has ~zero GenAI content and a CC BY-SA copyleft that would contaminate the dataset license — not ingested).

## What

- **`mappings/veris.json`** — hand-curated crosswalk from the controlled `attack_vector` vocabulary to VERIS 1.4.1 enum paths (35 vectors → 48 entries), anchored on 1.4.1's GenAI enums (`action.hacking.variety` "Prompt injection", asset "S - LLM application").
- **`export_misp.py`** — emits `veris:<predicate>="<value>"` machinetags on the title attribute, next to the existing `genai-incidents:*`/`mitre-atlas:*` tags. Missing mapping file degrades to no veris tags.
- **TAXONOMIES.md** — short "VERIS crosswalk (export-only)" section.

## Curation discipline

- Every entry mechanically verified against `verisc-enum.json` (case-exact) and the MISP veris-taxonomy predicate list; then adversarially reviewed against official VERIS definitions (`verisc-labels.json`), which re-curated six rows (e.g. poisoning → integrity "Modify data" because "Alter behavior" is officially *human* behavior; malware → "Unknown" rather than over-specifying "Trojan"; supply-chain → malware vector "Partner", VERIS's explicit supply-chain indicator).
- No honest equivalent → unmapped: `algorithmic-bias`, `adversarial-input`, `other`.
- **Not** derived by chaining ATLAS→ATT&CK→VERIS: only ~20% of ATLAS techniques have ATT&CK anchors, and none of the AI-native ones do.

## Why

Makes every incident legible to VERIS consumers — the DBIR contributor pipeline (~100 orgs incl. cyber insurers), FAIR-style risk quantification — through the existing MISP/TAXII plumbing, with zero schema surface. MISP ships a native `veris` taxonomy so tags render in subscribers' instances (its bundled copy predates 1.4.1, so the AI-specific tags show as plain tags until upstream refreshes — a possible follow-up PR to misp-taxonomies).

## Verification

- `pytest tests -q` — all pass; new tests cover tag emission (rce → `veris:action:hacking:variety="Exploit vuln"`), the unmapped case (no veris tags), and mapping-file well-formedness (known keys, predicate format, no quote injection).
- MISP feed artifacts are gitignored Pages build outputs — no committed data changes, drift-check-neutral.

Stacked PR: the `discovery_method` field PR is based on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)