### PR TITLE
feat: add optional discovery_method field for the landmark tier

### DIFF
--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -30,6 +30,7 @@ Every incident in [`data/incidents.json`](../data/incidents.json) follows
 | `affected` | string | Vendor / product / organization / system affected (free text). |
 | `impact` | string | Real-world consequence summary. |
 | `reversibility_class` | enum | Reversibility of the incident's **closing action**, ordered least→most severe: `read-only` → `reversible` → `external-reversible` → `irreversible` (see [TAXONOMIES.md](TAXONOMIES.md#reversibility-class), #74). Landmark-tier only, assigned via `data/curation_overrides.json` where source evidence describes the closing action (evidence + review date in the override `_note`). **Absence means unassessed, not `read-only`.** |
+| `discovery_method` | enum | How the incident was first surfaced: `security-researcher`, `actor-disclosure`, `customer-report`, `media-report`, `law-enforcement`, `internal-monitoring`, `internal-report`, `vendor-monitoring`, `other` (see [TAXONOMIES.md](TAXONOMIES.md#discovery-method); lineage: VERIS 1.4.1 `discovery_method`, flattened). Landmark-tier only, evidence-gated via `data/curation_overrides.json`. **Absence means unassessed, not internally detected.** |
 
 ## Framework mappings
 | Field | Type | Notes |

--- a/docs/TAXONOMIES.md
+++ b/docs/TAXONOMIES.md
@@ -12,6 +12,7 @@ This dataset maps each incident to four (sometimes five) taxonomies. They don't 
 | What adversary tactic/technique was used? | **MITRE ATLAS** |
 | Where in the architecture did it originate / impact? | **MAESTRO** (companion) |
 | Does response get paged or queued — could the closing action be undone? | **Reversibility class** (landmark tier) |
+| Which detection investment surfaced it? | **Discovery method** (landmark tier) |
 
 ---
 
@@ -148,6 +149,26 @@ Scope rules (precision-over-coverage):
 - **Evidence-gated** — assigned via `data/curation_overrides.json` only where the source evidence describes the closing action, with evidence and review date in the override `_note`. Feed/auto entries stay empty rather than guessing.
 - **Absence means unassessed, not `read-only`.**
 - The JSON-schema enum carries no order — consumers must rank explicitly (alphabetical sorting puts `irreversible` between the two reversible classes).
+
+---
+
+## Discovery method
+
+Lineage: [VERIS 1.4.1](https://github.com/vz-risk/veris) `discovery_method`, flattened from its external/internal/partner varieties and AI-adapted (`media-report` has no VERIS parent — journalist investigations surface many AI incidents). Severity says how bad, reversibility says paged-or-queued; `discovery_method` says **which detection investments actually surface GenAI incidents** — e.g. how many landmark incidents were found by external researchers versus the operator's own telemetry.
+
+| Value | Meaning (VERIS parent) |
+|---|---|
+| `security-researcher` | External researcher / bug bounty (Ext — Security researcher) |
+| `actor-disclosure` | The attacker announced, leaked, or extorted (Ext — Actor disclosure) |
+| `customer-report` | Affected user or customer reported it (Ext — Customer) |
+| `media-report` | Journalist or media investigation surfaced it (AI adaptation) |
+| `law-enforcement` | Law enforcement or regulator notified the operator (Ext — Law enforcement) |
+| `internal-monitoring` | Operator telemetry: logs, guardrails, anomaly detection (Int — Log review / monitoring) |
+| `internal-report` | Reported by an employee or insider (Int — Reported by employee) |
+| `vendor-monitoring` | Platform or model-provider abuse detection (Partner — Monitoring service) |
+| `other` | Known channel not listed above |
+
+Scope rules — identical to [Reversibility class](#reversibility-class): **landmark tier only** (validate.py integrity invariant), **evidence-gated** via `data/curation_overrides.json` (the source must state the discovery channel; evidence + review date in the override `_note`), and **absence means unassessed, not internally detected**.
 
 ---
 

--- a/schema/incident.schema.json
+++ b/schema/incident.schema.json
@@ -112,6 +112,11 @@
       "description": "Reversibility of the action that closed the incident (#74), ordered least→most severe: read-only = no state mutation; reversible = undoable in-session or by trivial in-system action; external-reversible = undoable only via an external compensating action (refund, retraction, cleanup); irreversible = no compensating action possible. Landmark-tier only, assigned via data/curation_overrides.json where source evidence describes the closing action. Absent = unassessed, NOT read-only. The enum carries no lexical order — consumers must rank explicitly.",
       "enum": ["read-only", "reversible", "external-reversible", "irreversible"]
     },
+    "discovery_method": {
+      "type": "string",
+      "description": "How the incident was first surfaced (lineage: VERIS 1.4.1 discovery_method, flattened and AI-adapted; media-report has no VERIS parent). Landmark-tier only, assigned via data/curation_overrides.json where the source states the discovery channel — same evidence-gated mechanism as reversibility_class (#74). Absent = unassessed, NOT internally detected.",
+      "enum": ["security-researcher", "actor-disclosure", "customer-report", "media-report", "law-enforcement", "internal-monitoring", "internal-report", "vendor-monitoring", "other"]
+    },
     "severity": {
       "type": "string",
       "enum": ["Critical", "High", "Medium", "Low", "Info"]

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -936,7 +936,7 @@ def _load_prev_timestamps() -> dict[str, tuple[str, str, dict]]:
 # bumps the timestamp, but `added`/`updated` themselves obviously do not.
 _CONTENT_FIELDS = (
     "title", "date", "year", "category", "description", "attack_vector",
-    "affected", "impact", "reversibility_class", "severity",
+    "affected", "impact", "reversibility_class", "discovery_method", "severity",
     "owasp_llm", "owasp_asi", "owasp_dsgai",
     "nist_ai_rmf", "mitre_atlas", "mitre_atlas_tactics", "cve_ids", "cwe_ids",
     "cvss_score", "cvss_vector", "aiid_id", "disclosure_date",

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -50,10 +50,11 @@ def check_integrity(data: dict, deprecations: list[dict] | None = None) -> list[
     5.   Scope gate (INCLUSION.md): no out-of-scope malicious-package entry
          may survive — makes the v2.3.1 scope-purge a hard, enforced
          invariant so the generic-malware noise can never return.
-    6.   Reversibility gate (#74): `reversibility_class` is a landmark-tier,
-         evidence-gated label. `tier` is re-derived every build, so an entry
-         drifting out of the landmark set must fail loudly rather than ship
-         a stale editorial judgment on a feed record.
+    6.   Landmark-label gate (#74): `reversibility_class` and
+         `discovery_method` are landmark-tier, evidence-gated labels. `tier`
+         is re-derived every build, so an entry drifting out of the landmark
+         set must fail loudly rather than ship a stale editorial judgment on
+         a feed record.
     """
     problems: list[str] = []
     incidents = data["incidents"]
@@ -87,14 +88,15 @@ def check_integrity(data: dict, deprecations: list[dict] | None = None) -> list[
                 f"scope purge (e.g. {', '.join(oos[:5])})"
             )
 
-    # 6) Reversibility gate — labels only on the landmark tier.
-    mislabeled = [e["id"] for e in incidents
-                  if e.get("reversibility_class") and e.get("tier") != "landmark"]
-    if mislabeled:
-        problems.append(
-            f"{len(mislabeled)} entr(ies) carry reversibility_class outside the "
-            f"landmark tier (e.g. {', '.join(mislabeled[:5])})"
-        )
+    # 6) Landmark-label gate — evidence-gated labels only on the landmark tier.
+    for label_field in ("reversibility_class", "discovery_method"):
+        mislabeled = [e["id"] for e in incidents
+                      if e.get(label_field) and e.get("tier") != "landmark"]
+        if mislabeled:
+            problems.append(
+                f"{len(mislabeled)} entr(ies) carry {label_field} outside the "
+                f"landmark tier (e.g. {', '.join(mislabeled[:5])})"
+            )
 
     if deprecations is not None:
         into_map = {d.get("from"): d.get("into") for d in deprecations}

--- a/src/genai_incidents/schema/incident.schema.json
+++ b/src/genai_incidents/schema/incident.schema.json
@@ -112,6 +112,11 @@
       "description": "Reversibility of the action that closed the incident (#74), ordered least→most severe: read-only = no state mutation; reversible = undoable in-session or by trivial in-system action; external-reversible = undoable only via an external compensating action (refund, retraction, cleanup); irreversible = no compensating action possible. Landmark-tier only, assigned via data/curation_overrides.json where source evidence describes the closing action. Absent = unassessed, NOT read-only. The enum carries no lexical order — consumers must rank explicitly.",
       "enum": ["read-only", "reversible", "external-reversible", "irreversible"]
     },
+    "discovery_method": {
+      "type": "string",
+      "description": "How the incident was first surfaced (lineage: VERIS 1.4.1 discovery_method, flattened and AI-adapted; media-report has no VERIS parent). Landmark-tier only, assigned via data/curation_overrides.json where the source states the discovery channel — same evidence-gated mechanism as reversibility_class (#74). Absent = unassessed, NOT internally detected.",
+      "enum": ["security-researcher", "actor-disclosure", "customer-report", "media-report", "law-enforcement", "internal-monitoring", "internal-report", "vendor-monitoring", "other"]
+    },
     "severity": {
       "type": "string",
       "enum": ["Critical", "High", "Medium", "Low", "Info"]

--- a/tests/test_merge_and_dedupe.py
+++ b/tests/test_merge_and_dedupe.py
@@ -668,6 +668,11 @@ def test_reversibility_class_is_content_field():
     assert "reversibility_class" in m._CONTENT_FIELDS
 
 
+def test_discovery_method_is_content_field():
+    # Same landmark-label mechanism as reversibility_class (#74).
+    assert "discovery_method" in m._CONTENT_FIELDS
+
+
 # ---------------------------------------------------------------------------
 # Inclusion-policy scope purge (v2.3.1) — drop / don't-retain out-of-scope malware
 # ---------------------------------------------------------------------------

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -91,6 +91,18 @@ def test_integrity_reversibility_gate_allows_landmark():
     assert not any("reversibility_class" in p for p in v.check_integrity(unlabeled, []))
 
 
+def test_integrity_discovery_method_gate_flags_non_landmark():
+    data = _data({"id": "INC-1", "tier": "feed",
+                  "discovery_method": "security-researcher"})
+    assert any("discovery_method" in p for p in v.check_integrity(data, []))
+
+
+def test_integrity_discovery_method_gate_allows_landmark():
+    data = _data({"id": "INC-1", "tier": "landmark",
+                  "discovery_method": "actor-disclosure"})
+    assert not any("discovery_method" in p for p in v.check_integrity(data, []))
+
+
 def test_integrity_scope_gate_flags_out_of_scope_malware():
     data = _data({"id": "INC-1", "tags": ["malicious-package"],
                   "affected": "npm/chai-mocks",


### PR DESCRIPTION
Second VERIS adoption (stacked on the crosswalk PR; GitHub retargets this to `main` when that merges): the one VERIS concept worth schema surface — **how the incident was first discovered**.

## What

`discovery_method` optional enum: `security-researcher` | `actor-disclosure` | `customer-report` | `media-report` | `law-enforcement` | `internal-monitoring` | `internal-report` | `vendor-monitoring` | `other`. Lineage: VERIS 1.4.1 `discovery_method` external/internal/partner varieties, flattened and AI-adapted (`media-report` has no VERIS parent — journalist investigations surface many AI incidents).

For SOC/IR consumers it answers *which detection investments actually surface GenAI incidents* — e.g. how many landmark incidents were found by external researchers versus the operator's own telemetry. No AI-incident tracker captures this today.

## Mechanism — identical to reversibility_class (#74, PR #76)

- Optional enum in both schema copies (byte-identical)
- Added to `_CONTENT_FIELDS` (label edits bump `updated` exactly once; drift-safe)
- validate.py landmark gate **generalized** over both label fields — a label outside `tier=landmark` fails CI
- Evidence-gated via `data/curation_overrides.json` (source must state the discovery channel)
- Docs: DATA_DICTIONARY row + TAXONOMIES section; **absence means unassessed, not internally detected**

## Verification

- `pytest tests -q` — 141 passed (new: content-field membership, landmark-gate flags feed-tier labels, landmark labels pass)
- `scripts/validate.py` against committed data — 12,024/12,024 valid, integrity clean (additive, nothing to migrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)