### PR TITLE
release: v2.6.0 — reversibility_class + discovery_method, VERIS crosswalk, 12,770 incidents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ The dataset uses [SemVer](https://semver.org/) — major bumps for breaking
 schema or ID changes, minor bumps for additive schema fields or large
 ingest expansions, patch bumps for routine refreshes and bug fixes.
 
+## [2.6.0] — 2026-07-02
+
+### Added (Schema — landmark-tier labels)
+- **`reversibility_class`** — optional enum (`read-only` / `reversible` /
+  `external-reversible` / `irreversible`) classifying the reversibility of the
+  action that closed the incident. Landmark-tier only, evidence-gated via
+  `data/curation_overrides.json`, enforced by a new validate.py integrity
+  invariant. Community proposal #74 (lineage: OWASP AISVS C09-02). (#76)
+- **`discovery_method`** — optional enum (`security-researcher`,
+  `actor-disclosure`, `customer-report`, `media-report`, `law-enforcement`,
+  `internal-monitoring`, `internal-report`, `vendor-monitoring`, `other`)
+  recording how the incident was first surfaced; same landmark gate (the
+  validate.py invariant now covers both label fields). Lineage: VERIS 1.4.1
+  `discovery_method`, flattened and AI-adapted. (#81)
+
+### Added (Integrations)
+- **VERIS 1.4.1 crosswalk** — hand-curated `mappings/veris.json` (35
+  attack_vectors → 48 enum entries, mechanically verified and adversarially
+  reviewed against official VERIS definitions), emitted as `veris:*`
+  machinetags in the MISP feed alongside `genai-incidents:*` /
+  `mitre-atlas:*`. Opens the dataset to VERIS consumers (DBIR contributor
+  pipeline, cyber insurers, FAIR-style risk quantification) with zero schema
+  surface. (#79)
+
+### Data
+- 11,658 → **12,770 incidents**: weekly auto-refresh (#75), OpenClaw
+  ingest-coverage fix (#77 — `openclaw` added to the NVD keyword list,
+  AI-context tokens, npm ecosystem allowlist and strict malware gate after
+  CVE-2026-44112 was missed on wording alone), and a CVE-enrichment run
+  (#78: +788 incidents including 276 previously-invisible OpenClaw
+  advisories and CVE-2026-44112 itself as INC-14014; +936 CVEs; all 42
+  removals recorded as merge deprecations).
+
+### Notes
+- Both new fields are additive and optional — absence means **unassessed**,
+  never a claim. No existing records were modified for the schema change.
+- Hardcoded marketing lower bound updated "11,500+" → "12,500+" (canonical
+  count remains `data/stats.json`).
+
 ## [2.5.0] — 2026-06-11
 
 ### Added (Coverage — linkage graph, #30)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -43,6 +43,6 @@ preferred-citation:
       given-names: "Emmanuel"
       alias: "emmanuelgjr"
   year: 2026
-  version: "2.4.0"
+  version: "2.6.0"
   doi: 10.5281/zenodo.20248676
   url: "https://doi.org/10.5281/zenodo.20248676"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,8 +33,8 @@ abstract: >-
   Framework (AI 100-1), and MITRE ATLAS. Aggregated from AIID, OECD AIM,
   AIAAIC, MITRE ATLAS, AVID, MIT FutureTech AI Risk Navigator, NVD/GHSA/OSV,
   garak, promptfoo, and dozens of researcher blogs and vendor threat reports.
-version: "2.5.0"
-date-released: "2026-06-11"
+version: "2.6.0"
+date-released: "2026-07-02"
 preferred-citation:
   type: dataset
   title: "GenAI & Agentic AI Security Incidents"

--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -3,7 +3,7 @@
 Single source of truth for GenAI and agentic AI security incidents.
 Each entry is mapped to **OWASP LLM Top 10 (2025)**, **OWASP Agentic Top 10 (ASI)**, **NIST AI RMF**, and **MITRE ATLAS**.
 
-- **Version:** 2.5.0
+- **Version:** 2.6.0
 - **Generated:** 2026-07-02
 - **Total incidents:** **12,770**
 - **Date range:** 1983 – 2026

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - 📄 **Methodology:** [`docs/paper/genai-incidents-methods.md`](docs/paper/genai-incidents-methods.md) — how the dataset is built, mapped, and governed
 - 📜 **Changelog:** [`CHANGELOG.md`](CHANGELOG.md)
 
-A single source of truth of **[11,500+ GenAI and agentic AI security incidents](https://emmanuelgjr.github.io/genai_incidents/)** (see the live count in the badge above), each mapped to:
+A single source of truth of **[12,500+ GenAI and agentic AI security incidents](https://emmanuelgjr.github.io/genai_incidents/)** (see the live count in the badge above), each mapped to:
 
 - **OWASP Top 10 for LLM Applications (2025)** — `LLM01`–`LLM10`
 - **OWASP Agentic Top 10 (ASI)** — `ASI01`–`ASI10`

--- a/data/incidents.min.json
+++ b/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.0",
+  "version": "2.6.0",
   "generated": "2026-07-02",
   "incident_count": 12770,
   "incidents": [

--- a/data/stats.json
+++ b/data/stats.json
@@ -1,7 +1,7 @@
 {
   "incident_count": 12770,
   "landmark_count": 1858,
-  "version": "2.5.0",
+  "version": "2.6.0",
   "generated": "2026-07-02",
   "year_min": 1983,
   "year_max": 2026

--- a/docs/app.js
+++ b/docs/app.js
@@ -184,7 +184,7 @@ function comparator() {
 
 function renderStats(allRows) {
   const total = allRows.length;
-  // Replace the static "11,500+" hero fallback with the exact live count.
+  // Replace the static "12,500+" hero fallback with the exact live count.
   const heroCount = document.getElementById('hero-count');
   if (heroCount) heroCount.textContent = fmtNum(total);
   const crit = allRows.filter(r => r.severity === 'Critical').length;

--- a/docs/data/incidents.min.json
+++ b/docs/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.0",
+  "version": "2.6.0",
   "generated": "2026-07-02",
   "incident_count": 12770,
   "incidents": [

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,14 +21,14 @@
   <!-- Open Graph / Twitter — rich link previews when shared -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="GenAI &amp; Agentic AI Security Incidents">
-  <meta property="og:description" content="11,500+ GenAI &amp; agentic-AI security incidents, mapped to OWASP LLM Top 10, OWASP Agentic, NIST AI RMF &amp; MITRE ATLAS. Searchable, filterable, open data (CC-BY-4.0).">
+  <meta property="og:description" content="12,500+ GenAI &amp; agentic-AI security incidents, mapped to OWASP LLM Top 10, OWASP Agentic, NIST AI RMF &amp; MITRE ATLAS. Searchable, filterable, open data (CC-BY-4.0).">
   <meta property="og:url" content="https://emmanuelgjr.github.io/genai_incidents/">
   <meta property="og:image" content="https://emmanuelgjr.github.io/genai_incidents/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="GenAI &amp; Agentic AI Security Incidents">
-  <meta name="twitter:description" content="11,500+ GenAI &amp; agentic-AI security incidents, mapped to OWASP LLM Top 10, OWASP Agentic, NIST AI RMF &amp; MITRE ATLAS.">
+  <meta name="twitter:description" content="12,500+ GenAI &amp; agentic-AI security incidents, mapped to OWASP LLM Top 10, OWASP Agentic, NIST AI RMF &amp; MITRE ATLAS.">
   <meta name="twitter:image" content="https://emmanuelgjr.github.io/genai_incidents/og-image.png">
   <link rel="preload" href="data/incidents.min.json" as="fetch" type="application/json" crossorigin>
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -80,7 +80,7 @@
 
     <div class="cta-row">
       <a class="cta" href="#incidents-table">Browse the full table ↓</a>
-      <span class="cta-hint"><span id="hero-count">11,500+</span> entries, fully filterable. Charts below let you click any bar to drill in.</span>
+      <span class="cta-hint"><span id="hero-count">12,500+</span> entries, fully filterable. Charts below let you click any bar to drill in.</span>
     </div>
 
     <section class="charts-section" aria-label="trends">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genai-incidents"
-version = "2.5.0"
+version = "2.6.0"
 description = "Curated dataset of GenAI & agentic-AI security incidents mapped to OWASP LLM Top 10, OWASP Agentic Top 10, NIST AI RMF, and MITRE ATLAS."
 readme = "README.md"
 license = "MIT"

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -1413,7 +1413,7 @@ def main():
 
     # 9) Write outputs
     out = {
-        "version": "2.5.0",
+        "version": "2.6.0",
         "generated": generated,
         "description": (
             "Single source of truth for GenAI and agentic AI security incidents. "

--- a/src/genai_incidents/data/incidents.min.json
+++ b/src/genai_incidents/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.0",
+  "version": "2.6.0",
   "generated": "2026-07-02",
   "incident_count": 12770,
   "incidents": [


### PR DESCRIPTION
Minor release: additive schema (two landmark-tier label fields), VERIS 1.4.1 interop, and the dataset growth merged since v2.5.0.

## What's in v2.6.0 (since v2.5.0)
- **`reversibility_class`** (#76, proposal #74) and **`discovery_method`** (#81) — optional, landmark-tier-only label fields, evidence-gated via `data/curation_overrides.json`, enforced by validate.py integrity invariants. Absence = unassessed.
- **VERIS 1.4.1 crosswalk** (#79) — `mappings/veris.json`, emitted as `veris:*` machinetags in the MISP feed.
- **OpenClaw ingest coverage** (#77) + weekly refresh (#75) + CVE enrichment (#78): dataset **11,658 → 12,770** (CVE-2026-44112 now INC-14014).
- Marketing lower bound "11,500+" → "12,500+" (canonical count stays `data/stats.json`).

## This PR
- Version 2.6.0 in all 4 sites: `pyproject.toml`, `merge_and_dedupe.py` data version, `CITATION.cff` ×2 (also fixes the nested `preferred-citation.version` that was left at 2.4.0 by the v2.5.0 bump) + `date-released: 2026-07-02`.
- CHANGELOG entry.
- Container-built data rebuild (version string only).

## Verification (two independent container builds, python:3.12-bookworm)
- 19,200 input → **12,770 unique**; **0 added / 0 removed** vs main; delta is the version string only.
- Build run twice → byte-identical (idempotent); `validate.py`: 12770/12770 valid, integrity invariants green.
- `pytest tests -q`: **141 passed**.
- Security pass: no new code paths — version strings, changelog markdown, meta-tag text, one JS comment. No new render surface.