### PR TITLE
fix: resolve all 5 open CodeQL alerts (URL host parsing, non-security MD5)

### DIFF
--- a/scripts/export_misp.py
+++ b/scripts/export_misp.py
@@ -163,7 +163,12 @@ def build(incidents: list[dict]) -> tuple[int, int]:
         for e in sorted(by_year[year], key=lambda x: x["id"]):
             for a in _incident_attributes(e):
                 attributes.append(a)
-                md5 = hashlib.md5(a["value"].encode("utf-8")).hexdigest()
+                # The MISP feed format matches attributes on the MD5 of the
+                # value (hashes.csv) — an interop identifier, not a security
+                # control.
+                md5 = hashlib.md5(
+                    a["value"].encode("utf-8"), usedforsecurity=False
+                ).hexdigest()
                 hash_lines.append(f"{md5},{ev_uuid}")
         n_attr += len(attributes)
 

--- a/scripts/ingest_aiaaic_sheet.py
+++ b/scripts/ingest_aiaaic_sheet.py
@@ -24,8 +24,23 @@ import re
 import sys
 import urllib.request
 from pathlib import Path
+from urllib.parse import urlparse
 
 from ingest_utils import conditional_fetch
+
+
+def _is_aiaaic_host(url: str) -> bool:
+    """True only when the URL's host is aiaaic.org or a subdomain.
+
+    Summary cells are untrusted upstream content; a plain substring test
+    would also match e.g. https://evil.example/aiaaic.org or
+    https://aiaaic.org.evil.example.
+    """
+    try:
+        host = urlparse(url).hostname or ""
+    except ValueError:
+        return False
+    return host == "aiaaic.org" or host.endswith(".aiaaic.org")
 
 ROOT = Path(__file__).resolve().parents[1]
 INGEST = ROOT / "ingest"
@@ -318,10 +333,11 @@ def normalize_row(raw_row: list[str], col: dict[str, int]) -> dict | None:
     references = []
     for u in urls[:8]:
         u_clean = u.strip(",.;")
-        rtype = "report" if "aiaaic.org" in u_clean else "news"
-        ref_title = "AIAAIC entry" if "aiaaic.org" in u_clean else u_clean
+        is_aiaaic = _is_aiaaic_host(u_clean)
+        rtype = "report" if is_aiaaic else "news"
+        ref_title = "AIAAIC entry" if is_aiaaic else u_clean
         references.append({"title": ref_title, "url": u_clean, "type": rtype})
-        if "aiaaic.org" in u_clean and "/aiaaic-repository/" in u_clean:
+        if is_aiaaic and "/aiaaic-repository/" in u_clean:
             slug = u_clean.rstrip("/").split("/")[-1]
             aiaaic_slug = slug
 

--- a/tests/test_render_markdown.py
+++ b/tests/test_render_markdown.py
@@ -83,7 +83,8 @@ def test_render_incident_block_produces_card():
     assert "Test incident" in body
     assert "prompt-injection" in body
     assert "LLM01" in body
-    assert "https://example.com" in re.findall(r"https?://[^\s)\"']+", body)
+    rendered_urls = re.findall(r"https?://[^\s)\"']+", body)
+    assert rendered_urls.count("https://example.com") == 1
 
 
 def test_render_incident_block_handles_minimal_entry():

--- a/tests/test_render_markdown.py
+++ b/tests/test_render_markdown.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import render_markdown as r
 
 
@@ -81,7 +83,7 @@ def test_render_incident_block_produces_card():
     assert "Test incident" in body
     assert "prompt-injection" in body
     assert "LLM01" in body
-    assert "https://example.com" in body
+    assert "https://example.com" in re.findall(r"https?://[^\s)\"']+", body)
 
 
 def test_render_incident_block_handles_minimal_entry():


### PR DESCRIPTION
Cleanup of every open code-scanning alert (all pre-existing, dating to May).

## py/incomplete-url-substring-sanitization (alerts #3, #4, #5)
`scripts/ingest_aiaaic_sheet.py` classified references with `"aiaaic.org" in url` — summary cells are untrusted upstream content, and a crafted URL like `https://evil.example/aiaaic.org` or `https://aiaaic.org.evil.example` would be classified as an AIAAIC report and could spoof the `aiaaic_slug`. Replaced with `_is_aiaaic_host()`: `urlparse().hostname` equality / `.aiaaic.org` suffix.

**Data impact: none.** All 1,514 unique URLs in the committed AIAAIC ingest snapshots classify identically under old and new logic (verified), so the next weekly refresh sees no reclassification. CI's drift check doesn't run ingest scripts.

## py/incomplete-url-substring-sanitization (alert #7)
`tests/test_render_markdown.py` asserted `"https://example.com" in body` (substring). Now equality-matches against URLs extracted from the rendered output — stricter test, no rule pattern.

## py/weak-sensitive-data-hashing (alert #9)
`scripts/export_misp.py` hashes attribute values with MD5 for `hashes.csv` — that is the MISP feed format's interop identifier (MISP fetchers match on value-MD5), not a security control, so the algorithm must stay MD5. Marked `usedforsecurity=False` with a comment.

## Verification
- Helper unit-checked: legit + subdomain URLs accepted; path/subdomain spoofs and malformed input rejected.
- `pytest tests -q`: 141 passed.
- MD5 output unchanged by `usedforsecurity=False` → identical hashes.csv.