### PR TITLE
docs: truth-pass — stale counts, v2.6.0 fields in datasheet/paper, STIX threading, HF size facet

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - 🤗 **Hugging Face:** [`emmanuelgjr/genai-incidents`](https://huggingface.co/datasets/emmanuelgjr/genai-incidents) — `load_dataset("emmanuelgjr/genai-incidents")` (built with `make huggingface`)
 - 🛰️ **STIX 2.1 bundle** (for OpenCTI / MISP / TAXII): <https://emmanuelgjr.github.io/genai_incidents/data/incidents.stix.json> — incidents as `x-genai-incident` SDOs linked to MITRE ATLAS `attack-pattern`s and CVE `vulnerability`s. Build locally with `make stix`.
 - 📡 **TAXII 2.1 (static):** discovery at <https://emmanuelgjr.github.io/genai_incidents/taxii2/discovery.json> — a read-only static mirror of the STIX collection ([usage + caveats](https://emmanuelgjr.github.io/genai_incidents/taxii2/README.md)). Build locally with `make taxii`.
-- 🛡️ **MISP feed:** subscribe a MISP instance to <https://emmanuelgjr.github.io/genai_incidents/misp/> (Format: *MISP Feed*) — incidents grouped into year-events with `genai-incidents:*` / `mitre-atlas:*` tags. Build locally with `make misp`.
+- 🛡️ **MISP feed:** subscribe a MISP instance to <https://emmanuelgjr.github.io/genai_incidents/misp/> (Format: *MISP Feed*) — incidents grouped into year-events with `genai-incidents:*` / `mitre-atlas:*` / VERIS 1.4.1 `veris:*` tags. Build locally with `make misp`.
 - 📖 **Field reference:** [`docs/DATA_DICTIONARY.md`](docs/DATA_DICTIONARY.md) · **Provenance & limitations:** [`docs/DATASHEET.md`](docs/DATASHEET.md)
 - 🎯 **Scope — what's in/out:** [`INCLUSION.md`](INCLUSION.md) (the inclusion policy every entry must satisfy)
 - 🛠️ **Spot an error?** Open a [data correction](https://github.com/emmanuelgjr/genai_incidents/issues/new?template=data_correction.yml) or [scope dispute](https://github.com/emmanuelgjr/genai_incidents/issues/new?template=scope_dispute.yml) — accepted changes are logged in [`CORRECTIONS.md`](CORRECTIONS.md)
@@ -49,6 +49,8 @@ The dataset is published as both a machine-readable JSON (`data/incidents.json`)
 │   ├── owasp_asi_top10.json
 │   ├── nist_ai_rmf.json
 │   ├── mitre_atlas.json
+│   ├── cwe_capec.json
+│   ├── veris.json
 │   └── maestro_layers.json
 ├── legacy/                     ← original source files (preserved verbatim)
 ├── ingest/                     ← per-source aggregator outputs (CVE, AIID, ATLAS, etc.)

--- a/docs/DATASHEET.md
+++ b/docs/DATASHEET.md
@@ -11,20 +11,24 @@ ATLAS — so developers, AppSec/threat-intel teams, and researchers can query,
 pivot, and cite incidents instead of re-scraping scattered trackers.
 
 ## Composition
-- **Instances:** consolidated incidents (currently 7,720), each an alleged
+- **Instances:** consolidated incidents (12,770 as of v2.6.0 — live count in
+  [`data/stats.json`](../data/stats.json)), each an alleged
   real-world harm, disclosed vulnerability, threat report, or research/red-team
   demonstration involving an AI system.
 - **Split:** `corpus` = `security` vs `ai-harm`; `category` distinguishes
   real-world from research/red-team/regulatory entries.
 - **Labels:** severity, attack_vector, and OWASP/NIST/ATLAS mappings — assigned
   by deterministic heuristics and, for a growing subset, human/assisted review
-  (see `quality_tier`).
+  (see `quality_tier`). Landmark-tier entries may additionally carry the
+  evidence-gated `reversibility_class` and `discovery_method` labels, assigned
+  only through curation overrides with closing-action evidence; absence means
+  unassessed (see [`TAXONOMIES.md`](TAXONOMIES.md)).
 - **Provenance:** every entry records its upstream `source_ids`.
 
 ## Collection
 Aggregated from public, credible sources: AI Incident Database (AIID), AIAAIC,
 OECD AI Incidents Monitor, MIT AI Risk Repository, MITRE ATLAS, AVID, NVD +
-GitHub Security Advisories + OSV.dev (AI/ML packages), OWASP, vendor threat
+GitHub Security Advisories + OSV.dev (AI/ML packages), CISA KEV, OWASP, vendor threat
 reports, and peer-reviewed venues (arXiv/USENIX/CCS/NDSS). Ingestion scripts
 live in [`scripts/`](../scripts); each source is re-pulled, normalized, then
 deduplicated by CVE / canonical URL / fuzzy title.
@@ -48,7 +52,7 @@ deduplicated by CVE / canonical URL / fuzzy title.
 - **Source & language bias:** English-language, Western-media-skewed; under-counts
   unreported or non-English incidents.
 - **Heuristic labels:** `auto`-tier mappings are unreviewed; `attack_vector`
-  `other` (~39%) reflects genuinely uncategorized harm incidents.
+  `other` (~36%) reflects genuinely uncategorized harm incidents.
 - **Recency lag:** very recent CVEs may lack CVSS until NVD scores them.
 - **Scope drift:** broad sources (AIAAIC/OECD) include pre-LLM algorithmic harms.
 - **Untrusted free text (security):** `title`, `description`, `affected`,
@@ -62,7 +66,10 @@ deduplicated by CVE / canonical URL / fuzzy title.
 
 ## Distribution & licence
 - **Data:** CC-BY-4.0. **Code:** MIT. DOI [10.5281/zenodo.20248676](https://doi.org/10.5281/zenodo.20248676).
-- Distributed via GitHub, PyPI (`genai-incidents`), Hugging Face Datasets, and a STIX 2.1 bundle.
+- Distributed via GitHub, PyPI (`genai-incidents`), Hugging Face Datasets, a
+  STIX 2.1 bundle, a static [TAXII 2.1 endpoint](https://emmanuelgjr.github.io/genai_incidents/taxii2/discovery.json),
+  and a [MISP feed](https://emmanuelgjr.github.io/genai_incidents/misp/) whose events
+  carry `genai-incidents:*`, `mitre-atlas:*`, and VERIS 1.4.1 `veris:*` machinetags.
 
 ## Maintenance
 Maintained at <https://github.com/emmanuelgjr/genai_incidents>; a weekly workflow

--- a/docs/TAXONOMIES.md
+++ b/docs/TAXONOMIES.md
@@ -150,6 +150,10 @@ Scope rules (precision-over-coverage):
 - **Absence means unassessed, not `read-only`.**
 - The JSON-schema enum carries no order — consumers must rank explicitly (alphabetical sorting puts `irreversible` between the two reversible classes).
 
+Boundary rules (settled in [#74](https://github.com/emmanuelgjr/genai_incidents/issues/74) on INC-03152, the Replit prod-DB deletion):
+- **Realized outcome, not intrinsic risk.** Classes describe what the closing action could actually undo per the documented outcome: `irreversible` requires that *no compensating action was possible* — an action that succeeded rules it out, however catastrophic the mutation could have been. Counterfactual severity is already carried by `severity` and `attack_vector`; misleading recoverability claims by the agent belong in the `_note` evidence.
+- **Vantage point is the acting agent's session, not the vendor's infrastructure.** `reversible` is reserved for undo available within the acting system's own session or controls and trivially exercised (trash restore, unsent internal draft). Ask **"who had to act?"** — if recovery needed anyone or anything outside the acting agent's session (a human operator, vendor tooling, backups), it is `external-reversible`, even when the tooling is platform-native.
+
 ---
 
 ## Discovery method

--- a/docs/paper/genai-incidents-methods.md
+++ b/docs/paper/genai-incidents-methods.md
@@ -91,7 +91,11 @@ heuristics seeded from the finalised attack vector, then cascaded
 fields under the determinism contract and are disputable via the corrections
 process. We make no claim that heuristic mappings are expert-reviewed for every
 entry; the `quality_tier` and `confidence` fields expose how vetted each record
-is.
+is. A further export-only crosswalk maps the controlled `attack_vector`
+vocabulary to VERIS 1.4.1 enum paths (`mappings/veris.json`), emitted as
+`veris:*` machinetags in the MISP feed — closest-defensible-enum curation,
+deliberately not derived by chaining ATLAS→ATT&CK→VERIS (see
+[`TAXONOMIES.md`](../TAXONOMIES.md)).
 
 ## 6. Schema and provenance
 
@@ -99,7 +103,13 @@ Every entry carries identity (`id`, `source_ids`), classification (severity,
 category, `corpus`), the five framework mappings, optional CVE/CWE/CVSS and KEV
 fields, and a **provenance block**: `quality_tier`, rule-derived `confidence`
 (high/medium/low), `source_count`, `source_status`, `first_seen`/`last_seen`,
-and `tier` (landmark vs feed). Free-text fields (`description`, etc.) are
+and `tier` (landmark vs feed). Landmark-tier entries may additionally carry two
+optional, evidence-gated labels — `reversibility_class` (reversibility of the
+incident's closing action) and `discovery_method` (how the incident was first
+surfaced; VERIS 1.4.1 lineage) — assigned only through
+`data/curation_overrides.json` with closing-action evidence in the override
+note and enforced by a landmark-tier integrity invariant; absence means
+unassessed. Free-text fields (`description`, etc.) are
 aggregated **verbatim and are untrusted** — they can contain raw HTML/exploit
 payloads — and must be escaped before rendering; the project's own renderer does
 so, and a CI guard enforces it.

--- a/scripts/export_huggingface.py
+++ b/scripts/export_huggingface.py
@@ -47,7 +47,7 @@ task_categories:
   - text-classification
   - text-retrieval
 size_categories:
-  - 1K<n<10K
+  - {size_cat}
 configs:
   - config_name: default
     data_files: incidents.jsonl
@@ -125,8 +125,11 @@ def build(out_dir: Path) -> tuple[int, Path]:
     with jsonl.open("w", encoding="utf-8", newline="\n") as fh:
         for inc in incidents:
             fh.write(json.dumps(inc, ensure_ascii=False, sort_keys=True) + "\n")
-    card = CARD.format(count=f"{len(incidents):,}", version=raw.get("version", "?"),
-                       repo="emmanuelgjr/genai-incidents")
+    n = len(incidents)
+    size_cat = ("n<1K" if n < 1_000 else "1K<n<10K" if n < 10_000
+                else "10K<n<100K" if n < 100_000 else "100K<n<1M")
+    card = CARD.format(count=f"{n:,}", version=raw.get("version", "?"),
+                       size_cat=size_cat, repo="emmanuelgjr/genai-incidents")
     (out_dir / "README.md").write_text(card, encoding="utf-8", newline="\n")
     return len(incidents), jsonl
 

--- a/scripts/export_stix.py
+++ b/scripts/export_stix.py
@@ -130,6 +130,11 @@ def build_bundle(incidents: list[dict]) -> dict:
             "x_mitre_atlas_tactics": i.get("mitre_atlas_tactics") or [],
             "x_cve_ids": i.get("cve_ids") or [],
         }
+        # Landmark-tier labels are optional and unassessed-by-absence: emit
+        # only when present so unlabeled entries carry no null/empty claim.
+        for opt in ("reversibility_class", "discovery_method"):
+            if i.get(opt):
+                sdo[f"x_{opt}"] = i[opt]
         objects.append(sdo)
         for t in i.get("mitre_atlas") or []:
             rid = _sid("relationship", iid, "uses", t)


### PR DESCRIPTION
Post-v2.6.0 consistency sweep: every documentation surface now tells the truth about the current dataset.

## DATASHEET.md
- Incident count was **badly stale: "currently 7,720"** (predates five releases) → now 12,770-as-of-v2.6.0 with a pointer to `data/stats.json` as the live count.
- `attack_vector: other` share ~39% → ~36% (actual: 35.9%).
- Labels section now documents the landmark-tier `reversibility_class` / `discovery_method` labels (evidence-gated, absence = unassessed).
- Collection adds CISA KEV (a real committed source since v2.3.0).
- Distribution adds the TAXII 2.1 endpoint and MISP feed with `genai-incidents:*` / `mitre-atlas:*` / `veris:*` machinetags.

## Methods paper
- §5 adds the export-only VERIS 1.4.1 crosswalk (closest-defensible-enum, why not ATLAS→ATT&CK→VERIS chaining).
- §6 adds the two optional landmark-tier labels and their evidence-gating mechanism.

## README (also the PyPI long description)
- MISP feed bullet now lists `veris:*` machinetags; layout tree adds `mappings/cwe_capec.json` + `mappings/veris.json`.

## scripts/export_huggingface.py
- `size_categories` was hardcoded `1K<n<10K` (wrong since the corpus passed 10K — affects HF search facets). Now derived from the record count; renders `10K<n<100K` today.

## scripts/export_stix.py
- Threads `x_reversibility_class` / `x_discovery_method` into the `x-genai-incident` SDO **only when present**, so unlabeled entries carry no null claim and the bundle stays deterministic. Today 0 entries carry them (no output change: verified 55,610 objects, same as before); the moment the first label lands, STIX/TAXII stay in sync with the canonical JSON.

## Explicitly NOT changed
- PyPI "mojibake" from the survey: **false alarm** — the live description decodes as clean UTF-8 with zero mojibake tokens and no lone surrogates; the garbling was a cp1252 console artifact on the Windows fetch side.
- ATLAS v5.6.0 version strings: owned by the in-flight ATLAS v2026.06 refresh PR.

## Verification
- `pytest tests -q`: 141 passed.
- `export_stix.py` smoke run: 55,610 objects for 12,770 incidents.
- `export_huggingface.py` smoke run: card renders `size_categories: 10K<n<100K`, 12,770 records.
- Docs-only + two exporter scripts; no drift-checked path touched (`git status` clean of generated files).