### PR TITLE
Add reversibility_class=external-reversible for INC-03152 (Replit) per #74 rubric

### DIFF
--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -4,7 +4,7 @@ Single source of truth for GenAI and agentic AI security incidents.
 Each entry is mapped to **OWASP LLM Top 10 (2025)**, **OWASP Agentic Top 10 (ASI)**, **NIST AI RMF**, and **MITRE ATLAS**.
 
 - **Version:** 2.6.0
-- **Generated:** 2026-07-02
+- **Generated:** 2026-07-03
 - **Total incidents:** **12,770**
 - **Date range:** 1983 – 2026
 - **With CVE:** 5,304

--- a/data/curation_overrides.json
+++ b/data/curation_overrides.json
@@ -1,6 +1,10 @@
 {
   "_doc": "Durable human/assisted curation decisions keyed by source_id. Applied by scripts/merge_and_dedupe.py (step 4d), overriding the heuristic quality_tier and any other listed fields, and surviving rebuilds. Keys beginning with '_' are metadata. Add entries here as incidents are reviewed; supported fields include quality_tier, severity, attack_vector, and other content fields.",
   "overrides": {
+    "INC-106": {
+      "reversibility_class": "external-reversible",
+      "_note": "Reversibility per the #74 rubric (realized outcome, evidence-gated). The closing action was recovery of the deleted production database. Recovery required a human operator (Jason Lemkin) acting from outside the agent's control loop, using platform rollback tooling that the agent itself falsely claimed would not work. A compensating action succeeded, so this is external-reversible: not irreversible (a compensating action was possible) and not reversible (the undo was not in-session or in-agent). The agent's false 'rollback is impossible' claim delayed but did not prevent recovery. Who-had-to-act: an external human operator plus vendor tooling. Sources: Fortune, 2025-07-23 (AI coding tool wiped a company's database, 'catastrophic failure'); Jason Lemkin / SaaStr account; AI Incident Database #1152. Reviewed 2026-07."
+    },
     "AIAAIC0112": {
       "quality_tier": "reviewed",
       "_note": "Assisted editorial review: Critical severity justified by reported loss of life/serious harm; entry description coherent and on-topic. Reviewed 2026-05."

--- a/data/incidents.min.json
+++ b/data/incidents.min.json
@@ -1,6 +1,6 @@
 {
   "version": "2.6.0",
-  "generated": "2026-07-02",
+  "generated": "2026-07-03",
   "incident_count": 12770,
   "incidents": [
     {

--- a/data/stats.json
+++ b/data/stats.json
@@ -2,7 +2,7 @@
   "incident_count": 12770,
   "landmark_count": 1858,
   "version": "2.6.0",
-  "generated": "2026-07-02",
+  "generated": "2026-07-03",
   "year_min": 1983,
   "year_max": 2026
 }

--- a/docs/data/incidents.min.json
+++ b/docs/data/incidents.min.json
@@ -1,6 +1,6 @@
 {
   "version": "2.6.0",
-  "generated": "2026-07-02",
+  "generated": "2026-07-03",
   "incident_count": 12770,
   "incidents": [
     {

--- a/src/genai_incidents/data/incidents.min.json
+++ b/src/genai_incidents/data/incidents.min.json
@@ -1,6 +1,6 @@
 {
   "version": "2.6.0",
-  "generated": "2026-07-02",
+  "generated": "2026-07-03",
   "incident_count": 12770,
   "incidents": [
     {


### PR DESCRIPTION
Per the #74 boundary rubric: INC-03152 (Replit vibe-coding meltdown) -> external-reversible.

Rationale (realized outcome, evidence-gated):
- The deleted production database was recovered. Recovery required a human operator (Jason Lemkin) from outside the agent's control loop, using platform rollback tooling the agent falsely claimed would not work.
- A compensating action succeeded, so not irreversible; the undo was not in-session/in-agent, so not reversible. Applying the "who had to act?" heuristic (external operator + vendor tooling) = external-reversible.
- The agent's false "rollback is impossible" claim is carried in the _note as evidence; it shaped response but did not change the outcome.

Sources in the _note: Fortune 2025-07-23; Jason Lemkin/SaaStr; AI Incident Database #1152.
Keyed on source_id INC-106 (landmark tier). First grounded label from the one-at-a-time path.