### PR TITLE
feat: refresh MITRE ATLAS mapping to v2026.06

### DIFF
--- a/docs/TAXONOMIES.md
+++ b/docs/TAXONOMIES.md
@@ -93,21 +93,22 @@ Key LLM-era techniques used heavily in this dataset:
 
 | Technique | Name |
 |---|---|
-| `AML.T0010` | ML Supply Chain Compromise |
-| `AML.T0018` | Backdoor ML Model |
+| `AML.T0010` | AI Supply Chain Compromise |
+| `AML.T0018` | Manipulate AI Model |
 | `AML.T0020` | Poison Training Data |
-| `AML.T0024` | Exfiltration via ML Inference API |
+| `AML.T0024` | Exfiltration via AI Inference API |
 | `AML.T0048` | External Harms |
-| `AML.T0051` | LLM Prompt Injection (`.000` Direct, `.001` Indirect) |
-| `AML.T0053` | LLM Plugin Compromise |
+| `AML.T0051` | LLM Prompt Injection (`.000` Direct, `.001` Indirect, `.002` Triggered) |
+| `AML.T0053` | AI Agent Tool Invocation |
 | `AML.T0054` | LLM Jailbreak |
 | `AML.T0056` | Extract LLM System Prompt |
 | `AML.T0057` | LLM Data Leakage |
-| `AML.T0066` | RAG Poisoning |
+| `AML.T0066` | Retrieval Content Crafting |
+| `AML.T0070` | RAG Poisoning |
 
 **Use it when:** you want to communicate the incident in adversarial-emulation terms — what an attacker is **doing**, not what is **broken**.
 
-See `mappings/mitre_atlas.json` for the full technique list used here.
+See `mappings/mitre_atlas.json` (pinned at ATLAS v2026.06) for the full technique list used here.
 
 ---
 

--- a/docs/paper/genai-incidents-methods.md
+++ b/docs/paper/genai-incidents-methods.md
@@ -87,7 +87,7 @@ fails on any drift. This is what makes the dataset reproducible and auditable.
 Mappings are produced by a combination of source-provided labels and
 heuristics seeded from the finalised attack vector, then cascaded
 (OWASP → ATLAS/NIST) via an authoritative technique→tactic map
-(`mappings/mitre_atlas.json`, ATLAS v5.6.0). Mapping decisions are content
+(`mappings/mitre_atlas.json`, ATLAS v2026.06). Mapping decisions are content
 fields under the determinism contract and are disputable via the corrections
 process. We make no claim that heuristic mappings are expert-reviewed for every
 entry; the `quality_tier` and `confidence` fields expose how vetted each record

--- a/mappings/mitre_atlas.json
+++ b/mappings/mitre_atlas.json
@@ -1,6 +1,6 @@
 {
   "framework": "MITRE ATLAS (Adversarial Threat Landscape for AI Systems)",
-  "version": "2024-2025",
+  "version": "2026.06",
   "url": "https://atlas.mitre.org/",
   "tactics": {
     "AML.TA0000": {
@@ -752,6 +752,9 @@
     "AML.T0091.000": {
       "name": "Application Access Token"
     },
+    "AML.T0091.001": {
+      "name": "Web Session Cookie"
+    },
     "AML.T0092": {
       "name": "Manipulate User LLM Chat History",
       "tactics": [
@@ -887,10 +890,22 @@
     },
     "AML.T0112.001": {
       "name": "AI Artifacts"
+    },
+    "AML.T0113": {
+      "name": "Steal Web Session Cookie",
+      "tactics": [
+        "AML.TA0013"
+      ]
+    },
+    "AML.T0114": {
+      "name": "AI Service Web Interface",
+      "tactics": [
+        "AML.TA0014"
+      ]
     }
   },
   "case_studies_url": "https://atlas.mitre.org/studies",
-  "note": "Technique list is current as of MITRE ATLAS 2025 publications; subtechniques use the .NNN suffix. Where ATLAS adds techniques in newer releases, this mapping file should be updated. Tactic IDs/names and technique->tactic links refreshed from mitre-atlas/atlas-data; each technique carries `tactics` (subtechniques inherit parent).",
+  "note": "Technique list is current as of MITRE ATLAS v2026.06 (mitre-atlas/atlas-data dist/v6/ATLAS-2026.06.yaml); subtechniques use the .NNN suffix. Where ATLAS adds techniques in newer releases, this mapping file should be updated. Tactic IDs/names and technique->tactic links refreshed from mitre-atlas/atlas-data; each technique carries `tactics` (subtechniques inherit parent). IDs retired upstream (AML.T0009, AML.T0030, AML.T0038, AML.T0045) are retained without `tactics` for entries that still reference them.",
   "technique_tactics_note": "Each technique entry carries its ATLAS tactic id(s) under `tactics` (subtechniques inherit the parent's).",
-  "atlas_data_version": "5.6.0"
+  "atlas_data_version": "2026.06"
 }

--- a/scripts/ingest_external.py
+++ b/scripts/ingest_external.py
@@ -62,56 +62,39 @@ ATLAS_TECH_TO_ASI = {
 }
 
 
+# Pinned ATLAS release parsed by ingest_atlas(). Upstream retired the
+# per-object data/ tree and froze dist/ATLAS.yaml at 5.6.0; the versioned
+# v6 dist files are the maintained, reproducible source.
+ATLAS_DIST = ("dist", "v6", "ATLAS-2026.06.yaml")
+
+
 def ingest_atlas() -> int:
-    atlas_dir = EXTERNAL / "atlas-data" / "data" / "case-studies"
-    if not atlas_dir.exists():
-        print("[atlas] case-studies dir missing — skipping")
+    dist = EXTERNAL / "atlas-data"
+    for part in ATLAS_DIST:
+        dist = dist / part
+    if not dist.exists():
+        print(f"[atlas] {'/'.join(ATLAS_DIST)} missing — skipping")
         return 0
+    try:
+        root = safe_yaml_load(dist.read_text(encoding="utf-8"))
+    except Exception as e:
+        print(f"  WARN: failed to parse {dist.name}: {e}")
+        return 0
+    if not isinstance(root, dict):
+        return 0
+    relationships = root.get("relationships") or {}
     out = []
-    # Also build a tactic lookup from the data/tactics files
-    tactics_dir = EXTERNAL / "atlas-data" / "data" / "tactics"
-    tactic_id_by_name = {}
-    if tactics_dir.exists():
-        for f in tactics_dir.glob("*.yaml"):
-            try:
-                d = safe_yaml_load(f.read_text(encoding="utf-8"))
-                if isinstance(d, dict):
-                    tactic_id_by_name[d.get("name", "").lower()] = d.get("id")
-            except Exception:
-                pass
 
-    # Technique reference map
-    tech_dir = EXTERNAL / "atlas-data" / "data" / "techniques"
-    tech_id_by_handle = {}
-    if tech_dir.exists():
-        for f in tech_dir.glob("*.yaml"):
-            try:
-                d = safe_yaml_load(f.read_text(encoding="utf-8"))
-                if isinstance(d, dict):
-                    # ATLAS uses jinja-like {{handle.id}} — try to derive handle from filename
-                    handle = f.stem.lower().replace(".", "_")
-                    tech_id_by_handle[handle] = d.get("id")
-                    if d.get("name"):
-                        tech_id_by_handle[d["name"].lower().replace(" ", "_")] = d.get("id")
-            except Exception:
-                pass
-
-    for f in sorted(atlas_dir.glob("AML.CS*.yaml")):
-        try:
-            cs = safe_yaml_load(f.read_text(encoding="utf-8"))
-        except Exception as e:
-            print(f"  WARN: failed to parse {f.name}: {e}")
-            continue
+    for cs_id, cs in sorted((root.get("case-studies") or {}).items()):
         if not isinstance(cs, dict):
             continue
 
-        cs_id = cs.get("id", f.stem)
-        title = cs.get("name", "").strip()
-        summary = cs.get("summary", "").strip()
+        title = (cs.get("name") or "").strip()
+        summary = (cs.get("description") or "").strip()
         if not title or not summary:
             continue
 
-        inc_date = cs.get("incident-date")
+        inc_date = cs.get("date")
         year = None
         date_str = ""
         if inc_date:
@@ -127,26 +110,17 @@ def ingest_atlas() -> int:
         if not year:
             year = 2020  # placeholder; ATLAS publishes pre-LLM cases too
 
-        # Extract technique IDs from procedure
+        # Technique/tactic IDs arrive fully resolved in the dist file's
+        # `employs` relationships (the old data/ tree needed jinja handles)
         atlas_tech = set()
         atlas_tactics = set()
-        for step in cs.get("procedure") or []:
-            t = step.get("technique") or ""
-            # technique field looks like '{{handle.id}}' — needs the handle map
-            m = re.search(r"\{\{\s*([a-z_0-9]+)\.id\s*\}\}", t)
-            if m:
-                handle = m.group(1)
-                resolved = tech_id_by_handle.get(handle)
-                if resolved:
-                    atlas_tech.add(resolved)
+        for step in (relationships.get(cs_id) or {}).get("employs") or []:
+            t = step.get("target") or ""
+            if t.startswith("AML.T") and not t.startswith("AML.TA"):
+                atlas_tech.add(t)
             tactic = step.get("tactic") or ""
-            m = re.search(r"\{\{\s*([a-z_0-9]+)\.id\s*\}\}", tactic)
-            if m:
-                handle = m.group(1)
-                # Try as tactic-style id
-                resolved = tech_id_by_handle.get(handle)
-                if resolved and resolved.startswith("AML.TA"):
-                    atlas_tactics.add(resolved)
+            if tactic.startswith("AML.TA"):
+                atlas_tactics.add(tactic)
 
         # Derive OWASP codes from techniques
         llm = set()
@@ -157,8 +131,8 @@ def ingest_atlas() -> int:
             for c in ATLAS_TECH_TO_ASI.get(t, []):
                 asi.add(c)
 
-        # Determine category
-        cat = cs.get("case-study-type", "incident")
+        # Determine category (v6 `type` is "Incident" or "Exercise")
+        cat = str(cs.get("type") or "incident").lower()
         category = "real-world" if cat == "incident" else "research"
 
         refs = []


### PR DESCRIPTION
Refreshes the MITRE ATLAS reference mapping from the deprecated v5.6.0 dist (`dist/ATLAS.yaml`, frozen upstream) to content release **v2026.06** (`dist/v6/ATLAS-2026.06.yaml` in mitre-atlas/atlas-data).

## Mapping changes (`mappings/mitre_atlas.json`)
- **3 technique entries added**:
  - `AML.T0113` — Steal Web Session Cookie (tactic `AML.TA0013` Credential Access)
  - `AML.T0114` — AI Service Web Interface (tactic `AML.TA0014` Command and Control)
  - `AML.T0091.001` — Web Session Cookie (subtechnique of Account Manipulation; inherits parent tactics)
- **0 renames, 0 removals, 0 technique→tactic link changes** for existing IDs between 5.6.0 and 2026.06 (verified by diffing both dists).
- `atlas_data_version` bumped `5.6.0` → `2026.06`; note updated to name the pinned versioned dist. IDs retired upstream before this release (`AML.T0009`, `AML.T0030`, `AML.T0038`, `AML.T0045`) stay in the mapping without `tactics` because dataset entries still reference them.

## Parser (`scripts/ingest_external.py`)
Upstream retired the per-object `data/` tree and froze `dist/ATLAS.yaml` at 5.6.0, so the ATLAS case-study parser now reads the pinned v6 dist (`ATLAS-2026.06.yaml`). Technique/tactic IDs come fully resolved from the `employs` relationships instead of the lossy jinja-handle heuristic. No ingest snapshot regeneration in this PR — `ingest/atlas_full.json` is unchanged.

## Docs
- `docs/paper/genai-incidents-methods.md` §5 now states ATLAS v2026.06.
- `docs/TAXONOMIES.md` technique-name table refreshed to current ATLAS names (T0066 is Retrieval Content Crafting; RAG Poisoning is T0070). CHANGELOG history untouched.

## Affected dataset entries: 0 of 12,770
The mapping feeds `merge_and_dedupe.py`'s technique→tactic derivation at merge time. The refresh is purely additive — no incident currently maps to the new technique IDs — so a full rebuild reproduces the committed data byte-for-byte and **no data commit is needed** (CI drift check passes on the fresh build).

## Verification (python:3.12-bookworm container, branch cloned inside container fs)
- `parse_existing` → `merge_and_dedupe` → `render_markdown` → `validate`: 12,770/12,770 entries valid, 0 errors; no duplicate CVE/source keys; all deprecations resolve.
- Composition vs `main`: count=12,770, added=0, removed=0; `mitre_atlas` changed: 0, `mitre_atlas_tactics` changed: 0, other-field changes: 0.
- Idempotency: second build pass byte-identical (sha256 over INCIDENTS.md, data/, docs/incidents|data|charts, src/genai_incidents/data|schema).
- `pytest tests -q`: 141 passed.
- Working-tree drift check after rebuild: clean — committed data already matches a fresh build.

## New ATLAS case studies (v2026.06 adds AML.CS0057–62) — future cross-reference candidates
Checked against `data/incidents.json` titles/descriptions; no schema or data changes here, listed for future cross-referencing:

| Case study | Dataset matches |
|---|---|
| AML.CS0057 Storm-2139 Azure OpenAI Guardrail Bypass | INC-02902, INC-03233, INC-03812 |
| AML.CS0058 Google Photos AI Model Extraction (Skyld TFLite recovery) | none |
| AML.CS0059 EchoLeak: Zero-Click Prompt Injection in M365 Copilot | INC-00924, INC-02539 (CVE-2025-32711), INC-00570 (variant research) |
| AML.CS0060 XSS via Prompt Manipulation in Lenovo AI Chatbot ("Lena") | none |
| AML.CS0061 AI in the Middle: Web-Based AI Services as C2 Relays | none |
| AML.CS0062 RCE in Semantic Kernel Search Plugin | INC-01440 (same CVE-2026-26030); related: INC-01762 (CVE-2026-25592, different vuln) |
