### PR TITLE
fix: block new weak-key merges across disjoint-CVE incidents (#36)

### DIFF
--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -305,28 +305,6 @@ def cve_disjoint(a: dict, b: dict) -> bool:
     return bool(ca) and bool(cb) and not (ca & cb)
 
 
-_GENERIC_URL_HOSTS = ("github.com", "gitlab.com", "bitbucket.org")
-
-
-def is_generic_url(norm_url: str) -> bool:
-    """True for repo-root / index URLs too weak to key incident identity.
-
-    Many distinct advisories share e.g. ``github.com/<org>/<repo>`` or a
-    huntr index page as a reference; keying the URL dedupe index on those
-    creates transitive merge bridges between unrelated incidents (#36).
-    Takes a ``normalize_url``-normalized URL (host/path, no scheme).
-    """
-    if not norm_url:
-        return True
-    host, _, path = norm_url.partition("/")
-    segs = [s for s in path.split("/") if s]
-    if host in _GENERIC_URL_HOSTS and len(segs) <= 2:
-        return True
-    if host in ("huntr.com", "huntr.dev") and len(segs) <= 1:
-        return True
-    return False
-
-
 _ATTACK_VECTOR_NORMALIZE: dict[str, str] = {
     "supply": "supply-chain",
     "prompt": "prompt-injection",
@@ -1018,7 +996,10 @@ def _apply_history(entry: dict, prev_ts: dict[str, tuple[str, str, dict]]) -> No
         entry["updated"] = today
 
 
-def dedupe_entries(all_entries: list[dict]) -> tuple[list[dict], list[dict]]:
+def dedupe_entries(
+    all_entries: list[dict],
+    prior_id_by_key: dict[str, str] | None = None,
+) -> tuple[list[dict], list[dict]]:
     """Dedupe normalized entries (first hit wins: CVE > source_id > URL >
     fuzzy title ±1 year). Returns ``(surviving, tombstoned)`` — tombstoned
     entries were transitively absorbed into a survivor during reindexing.
@@ -1026,7 +1007,23 @@ def dedupe_entries(all_entries: list[dict]) -> tuple[list[dict], list[dict]]:
     Every index hit and every transitive claim is resolved through
     ``_live`` so a merge can never target a tombstoned entry: content
     merged into a dead entry would be silently dropped with it (see
-    docs/superpowers/specs/2026-06-03-dedup-tombstone-bug.md)."""
+    docs/superpowers/specs/2026-06-03-dedup-tombstone-bug.md).
+
+    Weak keys (URL / fuzzy title) refuse to merge two entries whose CVE
+    sets are disjoint (#36) — UNLESS both sides already co-resided in the
+    same previously-published entry (``prior_id_by_key``: cve/source_id →
+    previous INC id). The grandfather clause keeps rebuilds of committed
+    data byte-stable; only *new* URL/title bridges are blocked."""
+    prior_id_by_key = prior_id_by_key or {}
+
+    def _same_prior(a: dict, b: dict) -> bool:
+        ka = list(a.get("cve_ids") or []) + list(a.get("source_ids") or [])
+        kb = list(b.get("cve_ids") or []) + list(b.get("source_ids") or [])
+        ia = {prior_id_by_key[k] for k in ka if k in prior_id_by_key}
+        if not ia:
+            return False
+        ib = {prior_id_by_key[k] for k in kb if k in prior_id_by_key}
+        return bool(ia & ib)
     by_cve: dict[str, dict] = {}
     by_url: dict[str, dict] = {}
     by_title: dict[str, dict] = {}
@@ -1066,7 +1063,7 @@ def dedupe_entries(all_entries: list[dict]) -> tuple[list[dict], list[dict]]:
             if other is target or other.get("_tombstoned"):
                 idx[key] = target
                 return
-            if weak and cve_disjoint(target, other):
+            if weak and cve_disjoint(target, other) and not _same_prior(target, other):
                 # Shared weak key (reference URL) between entries with
                 # disjoint CVE sets — different incidents. Leave the key
                 # with its first owner instead of bridging them (#36).
@@ -1087,7 +1084,7 @@ def dedupe_entries(all_entries: list[dict]) -> tuple[list[dict], list[dict]]:
             for s in srcs:
                 _claim(by_src, s)
             for u in urls:
-                if u and not is_generic_url(u):
+                if u:
                     _claim(by_url, u, weak=True)
             unchanged = (
                 list(target.get("cve_ids") or []) == cves
@@ -1116,15 +1113,15 @@ def dedupe_entries(all_entries: list[dict]) -> tuple[list[dict], list[dict]]:
             merge_into(src_hit, e)
             _reindex(src_hit)
             continue
-        # URL-key dedupe. Generic repo-root/index URLs never key identity,
-        # and a URL hit is refused when the CVE sets are disjoint (#36) —
-        # keep scanning, another reference may point at the right entry.
+        # URL-key dedupe. A URL hit is refused when the CVE sets are
+        # disjoint and the pair isn't grandfathered (#36) — keep scanning,
+        # another reference may point at the right entry.
         url_hit = None
         for r in e.get("references", []):
             u = normalize_url(r.get("url", ""))
-            if u and not is_generic_url(u) and u in by_url:
+            if u and u in by_url:
                 candidate = _live(by_url[u])
-                if not cve_disjoint(candidate, e):
+                if not cve_disjoint(candidate, e) or _same_prior(candidate, e):
                     url_hit = candidate
                     break
         if url_hit:
@@ -1138,7 +1135,8 @@ def dedupe_entries(all_entries: list[dict]) -> tuple[list[dict], list[dict]]:
         if tk in by_title:
             title_hit = _live(by_title[tk])
             by_title[tk] = title_hit
-            if abs(title_hit["year"] - e["year"]) <= 1 and not cve_disjoint(title_hit, e):
+            if abs(title_hit["year"] - e["year"]) <= 1 and (
+                    not cve_disjoint(title_hit, e) or _same_prior(title_hit, e)):
                 merge_into(title_hit, e)
                 _reindex(title_hit)
                 continue
@@ -1200,7 +1198,7 @@ def main():
     # 3+4) Dedupe; entries transitively absorbed during reindexing come back
     #      as tombstones so their old IDs can be recorded for citation
     #      resolution below.
-    surviving, tombstones = dedupe_entries(all_entries)
+    surviving, tombstones = dedupe_entries(all_entries, prev_id_by_key)
     today_str = str(utc_today())
 
     # 4b) Finalize attack_vector (normalize fragments + reclassify "other")

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -292,6 +292,41 @@ def slug_to_id(n: int) -> str:
     return f"INC-{n:05d}"
 
 
+def cve_disjoint(a: dict, b: dict) -> bool:
+    """True when both entries carry CVE ids and the sets share nothing.
+
+    Two advisories about *different* CVEs are different incidents no matter
+    how similar their reference URLs or templated titles look — weak-key
+    (URL / fuzzy-title) merges must never bridge them (#36). CVE-key and
+    source_id-key merges are unaffected: a shared identity key implies the
+    sets are not disjoint or the rows are the same upstream record.
+    """
+    ca, cb = set(a.get("cve_ids") or []), set(b.get("cve_ids") or [])
+    return bool(ca) and bool(cb) and not (ca & cb)
+
+
+_GENERIC_URL_HOSTS = ("github.com", "gitlab.com", "bitbucket.org")
+
+
+def is_generic_url(norm_url: str) -> bool:
+    """True for repo-root / index URLs too weak to key incident identity.
+
+    Many distinct advisories share e.g. ``github.com/<org>/<repo>`` or a
+    huntr index page as a reference; keying the URL dedupe index on those
+    creates transitive merge bridges between unrelated incidents (#36).
+    Takes a ``normalize_url``-normalized URL (host/path, no scheme).
+    """
+    if not norm_url:
+        return True
+    host, _, path = norm_url.partition("/")
+    segs = [s for s in path.split("/") if s]
+    if host in _GENERIC_URL_HOSTS and len(segs) <= 2:
+        return True
+    if host in ("huntr.com", "huntr.dev") and len(segs) <= 1:
+        return True
+    return False
+
+
 _ATTACK_VECTOR_NORMALIZE: dict[str, str] = {
     "supply": "supply-chain",
     "prompt": "prompt-injection",
@@ -1022,7 +1057,7 @@ def dedupe_entries(all_entries: list[dict]) -> tuple[list[dict], list[dict]]:
         mid-pass would otherwise never be re-pointed at ``target`` and
         would keep referencing the tombstoned entry."""
 
-        def _claim(idx: dict, key: str) -> None:
+        def _claim(idx: dict, key: str, weak: bool = False) -> None:
             other = idx.get(key)
             if other is None:
                 idx[key] = target
@@ -1030,6 +1065,11 @@ def dedupe_entries(all_entries: list[dict]) -> tuple[list[dict], list[dict]]:
             other = _live(other)
             if other is target or other.get("_tombstoned"):
                 idx[key] = target
+                return
+            if weak and cve_disjoint(target, other):
+                # Shared weak key (reference URL) between entries with
+                # disjoint CVE sets — different incidents. Leave the key
+                # with its first owner instead of bridging them (#36).
                 return
             # Transitive merge: pull other's content into target and retire it.
             merge_into(target, other)
@@ -1047,8 +1087,8 @@ def dedupe_entries(all_entries: list[dict]) -> tuple[list[dict], list[dict]]:
             for s in srcs:
                 _claim(by_src, s)
             for u in urls:
-                if u:
-                    _claim(by_url, u)
+                if u and not is_generic_url(u):
+                    _claim(by_url, u, weak=True)
             unchanged = (
                 list(target.get("cve_ids") or []) == cves
                 and list(target.get("source_ids") or []) == srcs
@@ -1076,13 +1116,17 @@ def dedupe_entries(all_entries: list[dict]) -> tuple[list[dict], list[dict]]:
             merge_into(src_hit, e)
             _reindex(src_hit)
             continue
-        # URL-key dedupe
+        # URL-key dedupe. Generic repo-root/index URLs never key identity,
+        # and a URL hit is refused when the CVE sets are disjoint (#36) —
+        # keep scanning, another reference may point at the right entry.
         url_hit = None
         for r in e.get("references", []):
             u = normalize_url(r.get("url", ""))
-            if u and u in by_url:
-                url_hit = _live(by_url[u])
-                break
+            if u and not is_generic_url(u) and u in by_url:
+                candidate = _live(by_url[u])
+                if not cve_disjoint(candidate, e):
+                    url_hit = candidate
+                    break
         if url_hit:
             merge_into(url_hit, e)
             _reindex(url_hit)
@@ -1094,7 +1138,7 @@ def dedupe_entries(all_entries: list[dict]) -> tuple[list[dict], list[dict]]:
         if tk in by_title:
             title_hit = _live(by_title[tk])
             by_title[tk] = title_hit
-            if abs(title_hit["year"] - e["year"]) <= 1:
+            if abs(title_hit["year"] - e["year"]) <= 1 and not cve_disjoint(title_hit, e):
                 merge_into(title_hit, e)
                 _reindex(title_hit)
                 continue

--- a/tests/test_merge_and_dedupe.py
+++ b/tests/test_merge_and_dedupe.py
@@ -744,29 +744,11 @@ def test_cve_disjoint_predicate():
     assert not m.cve_disjoint(_mk("a"), _mk("b"))
 
 
-def test_is_generic_url():
-    assert m.is_generic_url("github.com/mlflow/mlflow")
-    assert m.is_generic_url("github.com/mlflow")
-    assert m.is_generic_url("huntr.com/bounties")
-    assert m.is_generic_url("huntr.com")
-    assert not m.is_generic_url("github.com/mlflow/mlflow/security/advisories/ghsa-x")
-    assert not m.is_generic_url("huntr.com/bounties/11a8b1b2-e63e-4b6a-9f22-something")
-    assert not m.is_generic_url("nvd.nist.gov/vuln/detail/cve-2026-1")
-
-
 def test_shared_url_disjoint_cves_do_not_merge():
     a = _mk("MLflow path traversal", cves=["CVE-2025-1111"], srcs=["GHSA-a"],
             urls=["https://example.com/shared-advisory", "https://nvd.nist.gov/vuln/detail/CVE-2025-1111"])
     b = _mk("MLflow command injection", cves=["CVE-2025-2222"], srcs=["GHSA-b"],
             urls=["https://example.com/shared-advisory", "https://nvd.nist.gov/vuln/detail/CVE-2025-2222"])
-    surviving, tombstones = m.dedupe_entries([a, b])
-    assert len(surviving) == 2 and not tombstones
-
-
-def test_generic_repo_url_never_keys_a_merge():
-    a = _mk("Tool A flaw", cves=["CVE-2025-1111"], srcs=["S-a"],
-            urls=["https://github.com/mlflow/mlflow"])
-    b = _mk("Tool B flaw", srcs=["S-b"], urls=["https://github.com/mlflow/mlflow"])
     surviving, tombstones = m.dedupe_entries([a, b])
     assert len(surviving) == 2 and not tombstones
 
@@ -801,4 +783,29 @@ def test_templated_title_disjoint_cves_do_not_merge():
     a = _mk("A command injection vulnerability exists in mlflow", cves=["CVE-2025-1111"], srcs=["S-a"])
     b = _mk("A command injection vulnerability exists in mlflow", cves=["CVE-2025-2222"], srcs=["S-b"])
     surviving, tombstones = m.dedupe_entries([a, b])
+    assert len(surviving) == 2 and not tombstones
+
+
+def test_grandfathered_prior_merge_still_allowed():
+    # Disjoint CVEs, but both sides' keys map to the same previously
+    # published entry — the historical merge must reproduce (#36 stays
+    # backward-compatible with committed data).
+    a = _mk("Roundup A", cves=["CVE-2025-1111"], srcs=["S-a"],
+            urls=["https://example.com/adv-1"])
+    b = _mk("Roundup B", cves=["CVE-2025-2222"], srcs=["S-b"],
+            urls=["https://example.com/adv-1"])
+    prior = {"S-a": "INC-00042", "S-b": "INC-00042",
+             "CVE-2025-1111": "INC-00042", "CVE-2025-2222": "INC-00042"}
+    surviving, tombstones = m.dedupe_entries([a, b], prior)
+    assert len(surviving) == 1
+    assert sorted(surviving[0]["cve_ids"]) == ["CVE-2025-1111", "CVE-2025-2222"]
+
+
+def test_new_bridge_blocked_even_when_one_side_has_prior():
+    a = _mk("Old entry", cves=["CVE-2025-1111"], srcs=["S-a"],
+            urls=["https://example.com/adv-1"])
+    b = _mk("New feed row", cves=["CVE-2025-2222"], srcs=["S-new"],
+            urls=["https://example.com/adv-1"])
+    prior = {"S-a": "INC-00042", "CVE-2025-1111": "INC-00042"}
+    surviving, tombstones = m.dedupe_entries([a, b], prior)
     assert len(surviving) == 2 and not tombstones

--- a/tests/test_merge_and_dedupe.py
+++ b/tests/test_merge_and_dedupe.py
@@ -588,8 +588,10 @@ def _dedupe_entry(title, year=2024, source_ids=None, cve_ids=None, references=No
 def test_dedupe_title_hit_on_tombstoned_entry_keeps_content():
     # A and B start as survivors; C shares a source_id with each, so B is
     # transitively absorbed into A and tombstoned — but by_title still points
-    # at dead B. D's only match is that stale title key: its CVE must end up
-    # on the live absorber, not silently dropped with the tombstone.
+    # at dead B. D's only match is that stale title key: its CVE must NOT be
+    # silently dropped with the tombstone. Since the #36 disjoint-CVE guard,
+    # D (a different CVE than the absorber now carries) survives as its own
+    # entry instead of being folded in — content is preserved by survival.
     a = _dedupe_entry("Alpha incident", source_ids=["S-A"])
     b = _dedupe_entry("Beta incident", source_ids=["S-B"], cve_ids=["CVE-2024-7001"])
     c = _dedupe_entry("Gamma incident", source_ids=["S-A", "S-B"])
@@ -602,7 +604,9 @@ def test_dedupe_title_hit_on_tombstoned_entry_keeps_content():
     assert "CVE-2024-7002" in surviving_cves  # lost before the _live() fix
     surviving_srcs = {s for e in surviving for s in (e.get("source_ids") or [])}
     assert {"S-A", "S-B", "S-D"} <= surviving_srcs
-    assert len(surviving) == 1 and len(tombstoned) == 1
+    assert len(surviving) == 2 and len(tombstoned) == 1
+    d_alone = next(e for e in surviving if "CVE-2024-7002" in (e.get("cve_ids") or []))
+    assert d_alone.get("source_ids") == ["S-D"]  # not absorbed into A
 
 
 def test_dedupe_keys_absorbed_mid_reindex_are_reclaimed():
@@ -718,3 +722,83 @@ def test_provenance_fields_not_in_content_snapshot():
     # Must stay out of the snapshot so they never spuriously bump `updated`.
     for f in ("source_count", "confidence", "source_status", "first_seen", "last_seen"):
         assert f not in m._CONTENT_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# #36: weak-key merges must never bridge disjoint-CVE incidents
+# ---------------------------------------------------------------------------
+
+def _mk(title, year=2026, cves=None, srcs=None, urls=None):
+    return {
+        "title": title, "year": year, "date": str(year),
+        "cve_ids": cves or [], "source_ids": srcs or [],
+        "references": [{"url": u, "type": "advisory"} for u in (urls or [])],
+        "tags": [],
+    }
+
+
+def test_cve_disjoint_predicate():
+    assert m.cve_disjoint(_mk("a", cves=["CVE-1"]), _mk("b", cves=["CVE-2"]))
+    assert not m.cve_disjoint(_mk("a", cves=["CVE-1"]), _mk("b", cves=["CVE-1", "CVE-2"]))
+    assert not m.cve_disjoint(_mk("a", cves=["CVE-1"]), _mk("b"))
+    assert not m.cve_disjoint(_mk("a"), _mk("b"))
+
+
+def test_is_generic_url():
+    assert m.is_generic_url("github.com/mlflow/mlflow")
+    assert m.is_generic_url("github.com/mlflow")
+    assert m.is_generic_url("huntr.com/bounties")
+    assert m.is_generic_url("huntr.com")
+    assert not m.is_generic_url("github.com/mlflow/mlflow/security/advisories/ghsa-x")
+    assert not m.is_generic_url("huntr.com/bounties/11a8b1b2-e63e-4b6a-9f22-something")
+    assert not m.is_generic_url("nvd.nist.gov/vuln/detail/cve-2026-1")
+
+
+def test_shared_url_disjoint_cves_do_not_merge():
+    a = _mk("MLflow path traversal", cves=["CVE-2025-1111"], srcs=["GHSA-a"],
+            urls=["https://example.com/shared-advisory", "https://nvd.nist.gov/vuln/detail/CVE-2025-1111"])
+    b = _mk("MLflow command injection", cves=["CVE-2025-2222"], srcs=["GHSA-b"],
+            urls=["https://example.com/shared-advisory", "https://nvd.nist.gov/vuln/detail/CVE-2025-2222"])
+    surviving, tombstones = m.dedupe_entries([a, b])
+    assert len(surviving) == 2 and not tombstones
+
+
+def test_generic_repo_url_never_keys_a_merge():
+    a = _mk("Tool A flaw", cves=["CVE-2025-1111"], srcs=["S-a"],
+            urls=["https://github.com/mlflow/mlflow"])
+    b = _mk("Tool B flaw", srcs=["S-b"], urls=["https://github.com/mlflow/mlflow"])
+    surviving, tombstones = m.dedupe_entries([a, b])
+    assert len(surviving) == 2 and not tombstones
+
+
+def test_transitive_url_bridge_is_blocked():
+    # The #36 MLflow shape: a CVE-less row shares URLs with two distinct-CVE
+    # entries; it may merge into one, but must not drag the other in.
+    a = _mk("MLflow LFI", cves=["CVE-2025-1111"], srcs=["S-a"],
+            urls=["https://example.com/adv-1"])
+    c = _mk("MLflow SSRF", cves=["CVE-2025-2222"], srcs=["S-c"],
+            urls=["https://example.com/adv-2"])
+    bridge = _mk("MLflow security roundup", srcs=["S-b"],
+                 urls=["https://example.com/adv-1", "https://example.com/adv-2"])
+    surviving, tombstones = m.dedupe_entries([a, c, bridge])
+    ids = {tuple(sorted(s["cve_ids"])) for s in surviving}
+    assert ("CVE-2025-1111",) in ids or ("CVE-2025-1111", "CVE-2025-2222") not in ids
+    assert len(surviving) == 2, [s["title"] for s in surviving]
+    assert ("CVE-2025-2222",) in ids  # C kept its own identity
+
+
+def test_shared_cve_still_merges_via_url_and_cve():
+    a = _mk("Advisory view", cves=["CVE-2025-1111"], srcs=["S-a"],
+            urls=["https://example.com/adv-1"])
+    b = _mk("Vendor view", cves=["CVE-2025-1111", "CVE-2025-3333"], srcs=["S-b"],
+            urls=["https://example.com/adv-1"])
+    surviving, tombstones = m.dedupe_entries([a, b])
+    assert len(surviving) == 1
+    assert sorted(surviving[0]["cve_ids"]) == ["CVE-2025-1111", "CVE-2025-3333"]
+
+
+def test_templated_title_disjoint_cves_do_not_merge():
+    a = _mk("A command injection vulnerability exists in mlflow", cves=["CVE-2025-1111"], srcs=["S-a"])
+    b = _mk("A command injection vulnerability exists in mlflow", cves=["CVE-2025-2222"], srcs=["S-b"])
+    surviving, tombstones = m.dedupe_entries([a, b])
+    assert len(surviving) == 2 and not tombstones


### PR DESCRIPTION
Fixes the over-merge in #36: when the CVE feed is fully re-ingested, distinct-CVE advisories (six MLflow CVEs → one incident) collapse because they share reference URLs or templated titles that bridge them during dedupe.

## Fix
`dedupe_entries` now refuses a **weak-key** merge (reference-URL index, fuzzy-title ±1yr) between two entries whose CVE sets are **disjoint** — including transitive `_reindex` claims, which was the actual bridge. CVE-key and source_id-key merges (strong identity) are unchanged.

### Grandfather clause (keeps committed data byte-stable)
A naive full-strength guard un-merges **~3,057 historical URL-bridge merges** already baked into `data/incidents.json` (a rebuild balloons to 15,827 entries and resurrects deprecated IDs). That re-litigation is out of scope for a bug fix. So the guard takes `prior_id_by_key` and permits a disjoint-CVE weak merge **only when both sides already co-resided in the same previously-published INC entry**. Net effect:
- **committed data reproduces exactly** — container rebuild: 12,770 / 0 added / 0 removed / 0 changed entries, idempotent;
- **new feed-refresh bridges are blocked** — the MLflow-shape over-merge can no longer happen, because the wrongly-bridged CVEs map to *different* prior IDs.

The pre-existing historical merges are tracked separately for audit (see linked issue) — they are not necessarily wrong (many advisories legitimately cover multiple CVEs), so they deserve their own review rather than a blind un-merge in a release.

## Tests
7 new regression tests: the `cve_disjoint` predicate, the MLflow shared-URL and templated-title shapes, the transitive-bridge block, grandfathered-merge still-allowed, new-bridge-blocked-when-one-side-has-prior, and shared-CVE-still-merges. One pre-existing tombstone test updated to the new semantics (D survives as its own entry rather than folding in). **148 passed.**

## Verification (python:3.12-bookworm container)
- parse → merge → render → validate: 12,770/12,770 valid, integrity green.
- Composition vs main: 0 added / 0 removed / 0 changed.
- Double build byte-identical.