### PR TITLE
release: v2.7.0 — ATLAS v2026.06, 844 CWE reclassifications, first reversibility label, #36 dedupe fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ The dataset uses [SemVer](https://semver.org/) — major bumps for breaking
 schema or ID changes, minor bumps for additive schema fields or large
 ingest expansions, patch bumps for routine refreshes and bug fixes.
 
+## [2.7.0] — 2026-07-03
+
+Data-quality and interoperability release. Incident composition is unchanged
+from v2.6.0 (12,770 entries, 0 added / 0 removed) — the work is in
+classification precision, threat-intel mapping freshness, and the first
+populated landmark-tier label.
+
+### Changed (interoperability)
+- **MITRE ATLAS mapping refreshed to content v2026.06** (`mappings/mitre_atlas.json`;
+  ATLAS froze the old `dist/ATLAS.yaml` at 5.6.0, so `scripts/ingest_external.py`
+  now parses the pinned `dist/v6/ATLAS-2026.06.yaml`). Adds techniques
+  `AML.T0113`, `AML.T0114`, `AML.T0091.001`; no renames or removals for existing
+  IDs. (#86)
+
+### Changed (classification precision)
+- **844 `attack_vector: other` entries reclassified from unanimous CWE evidence**
+  (`other` 4,589 → 3,745). A new `mappings/cwe_attack_vector.json` maps 35
+  unambiguous CWE classes to 10 vectors, applied only when text classification
+  left an entry at `other` **and** every mappable CWE on it agrees (unanimity
+  rule — mixed signals stay `other`). A 50-entry random sample reviewed 50/50
+  defensible. (#89)
+
+### Added (first labels)
+- **First `reversibility_class` label populated** — INC-03152 (the Replit
+  agent production-database deletion) classified `external-reversible`, with
+  closing-action evidence in the curation override. The boundary rubric
+  (realized-outcome, "who had to act?") is now documented in `TAXONOMIES.md`.
+  First community-contributed label (proposal #74). (#85)
+
+### Fixed
+- **Dedupe no longer over-merges distinct-CVE incidents** on a full CVE-feed
+  refresh — weak keys (shared reference URL, templated title) can no longer
+  bridge two entries with disjoint CVE sets, including transitive claims
+  (the shape that collapsed six distinct MLflow CVEs into one). Historical
+  merges are grandfathered so committed data is byte-stable. (#87, #36)
+
+### Docs
+- Datasheet/methods-paper truth-pass: incident count corrected, the two v2.6.0
+  landmark labels and the VERIS crosswalk documented, TAXII/MISP distribution
+  and `veris:*` machinetags surfaced; Hugging Face `size_categories` now
+  derived from the record count. (#84)
+
 ## [2.6.0] — 2026-07-02
 
 ### Added (Schema — landmark-tier labels)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,8 +33,8 @@ abstract: >-
   Framework (AI 100-1), and MITRE ATLAS. Aggregated from AIID, OECD AIM,
   AIAAIC, MITRE ATLAS, AVID, MIT FutureTech AI Risk Navigator, NVD/GHSA/OSV,
   garak, promptfoo, and dozens of researcher blogs and vendor threat reports.
-version: "2.6.0"
-date-released: "2026-07-02"
+version: "2.7.0"
+date-released: "2026-07-03"
 preferred-citation:
   type: dataset
   title: "GenAI & Agentic AI Security Incidents"
@@ -43,6 +43,6 @@ preferred-citation:
       given-names: "Emmanuel"
       alias: "emmanuelgjr"
   year: 2026
-  version: "2.6.0"
+  version: "2.7.0"
   doi: 10.5281/zenodo.20248676
   url: "https://doi.org/10.5281/zenodo.20248676"

--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -3,7 +3,7 @@
 Single source of truth for GenAI and agentic AI security incidents.
 Each entry is mapped to **OWASP LLM Top 10 (2025)**, **OWASP Agentic Top 10 (ASI)**, **NIST AI RMF**, and **MITRE ATLAS**.
 
-- **Version:** 2.6.0
+- **Version:** 2.7.0
 - **Generated:** 2026-07-03
 - **Total incidents:** **12,770**
 - **Date range:** 1983 – 2026

--- a/data/incidents.min.json
+++ b/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.0",
+  "version": "2.7.0",
   "generated": "2026-07-03",
   "incident_count": 12770,
   "incidents": [

--- a/data/stats.json
+++ b/data/stats.json
@@ -1,7 +1,7 @@
 {
   "incident_count": 12770,
   "landmark_count": 1858,
-  "version": "2.6.0",
+  "version": "2.7.0",
   "generated": "2026-07-03",
   "year_min": 1983,
   "year_max": 2026

--- a/docs/data/incidents.min.json
+++ b/docs/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.0",
+  "version": "2.7.0",
   "generated": "2026-07-03",
   "incident_count": 12770,
   "incidents": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genai-incidents"
-version = "2.6.0"
+version = "2.7.0"
 description = "Curated dataset of GenAI & agentic-AI security incidents mapped to OWASP LLM Top 10, OWASP Agentic Top 10, NIST AI RMF, and MITRE ATLAS."
 readme = "README.md"
 license = "MIT"

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -1491,7 +1491,7 @@ def main():
 
     # 9) Write outputs
     out = {
-        "version": "2.6.0",
+        "version": "2.7.0",
         "generated": generated,
         "description": (
             "Single source of truth for GenAI and agentic AI security incidents. "

--- a/src/genai_incidents/data/incidents.min.json
+++ b/src/genai_incidents/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.6.0",
+  "version": "2.7.0",
   "generated": "2026-07-03",
   "incident_count": 12770,
   "incidents": [


### PR DESCRIPTION
Data-quality + interoperability release. **Incident composition unchanged from v2.6.0** (12,770 / 0 added / 0 removed) — the value is in classification precision, threat-intel mapping freshness, the first populated landmark label, and a dedupe correctness fix.

## Contents (merged since v2.6.0)
- **ATLAS mapping → content v2026.06** (#86) — +AML.T0113/T0114/T0091.001; ingest now parses the pinned `dist/v6` YAML.
- **844 `attack_vector: other` reclassified from unanimous CWE evidence** (#89) — `other` 4,589 → 3,745; 50/50 sample defensible.
- **First `reversibility_class` label** (#85, #74) — INC-03152 → external-reversible; boundary rubric documented in TAXONOMIES.md.
- **#36 dedupe over-merge fixed** (#87) — disjoint-CVE weak-key bridges blocked, committed data grandfathered.
- **Docs truth-pass** (#84) — stale counts corrected, v2.6.0 fields + VERIS/TAXII/MISP documented, HF size facet derived.

## This PR
- Version 2.7.0 in all 4 sites (`pyproject.toml`, `merge_and_dedupe.py`, `CITATION.cff` ×2) + `date-released: 2026-07-03`. Marketing lower bound stays "12,500+" (count 12,770 unchanged).
- CHANGELOG entry. Container-built data rebuild (version string only).

## Verification (python:3.12-bookworm container)
- 19,200 input → 12,770 unique; **0 added / 0 removed** vs main; delta is the version string.
- Built twice, byte-identical (idempotent); `validate.py` green; **152 tests pass**.