### PR TITLE
release: v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ The dataset uses [SemVer](https://semver.org/) — major bumps for breaking
 schema or ID changes, minor bumps for additive schema fields or large
 ingest expansions, patch bumps for routine refreshes and bug fixes.
 
+## [2.8.0] — 2026-07-13
+
+Data-quality release. Net composition 12,770 → 12,986 (+241 from the weekly
+source refresh, −25 from removing non-GenAI scope contamination); landmark
+1,858 → 1,865.
+
+### Removed (scope precision)
+- **25 non-GenAI CVE-bridge buckets excluded** per INCLUSION.md — entries where
+  a weak key (shared reference URL / templated title) had collapsed dozens to
+  hundreds of *unrelated, non-GenAI* CVE advisories into one incident:
+  `dexidp/dex` (708 CVEs, was landmark), Juju (93, was landmark), ~11 ×
+  Magento/Adobe Commerce, KaiOS, Google Chrome, four Jenkins plugins, Liferay,
+  Mattermost, MantisBT, jackson-dataformat-toml, Firefox. Decisions and
+  per-bucket rationale in `data/issue88_remediation.json`; each removal carries
+  an `out-of-scope` deprecation so citations still resolve. The excluded
+  buckets' source keys are suppressed **before** dedupe (enumerated statically),
+  so the removal is idempotent and cannot resurrect on rebuild. (#88, #95)
+
+### Added (labels)
+- **55 landmark-tier `reversibility_class` / `discovery_method` labels**
+  populated across two evidence-gated curation batches, each label citing
+  closing-action or discovery-channel evidence in `data/curation_overrides.json`.
+  (#91, #92)
+
+### Changed
+- **Weekly source refresh** — AIRI Navigator, AIAAIC, OECD AI Incidents Monitor
+  (+241 incidents net; routine dedupe deprecations recorded). (#93)
+
+### Tooling
+- **`scripts/audit_cve_bridge.py`** — reproducible precision audit of the
+  grandfathered disjoint-CVE weak-key merges (#36), classifying each multi-CVE
+  incident. It surfaced the scope-contamination removed above and characterises
+  the remaining GenAI over-merges (a ~542-advisory recovery) as the v3.0 one-way
+  split re-baseline tracked in #88. (#94)
+
 ## [2.7.0] — 2026-07-03
 
 Data-quality and interoperability release. Incident composition is unchanged

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -33,8 +33,8 @@ abstract: >-
   Framework (AI 100-1), and MITRE ATLAS. Aggregated from AIID, OECD AIM,
   AIAAIC, MITRE ATLAS, AVID, MIT FutureTech AI Risk Navigator, NVD/GHSA/OSV,
   garak, promptfoo, and dozens of researcher blogs and vendor threat reports.
-version: "2.7.0"
-date-released: "2026-07-03"
+version: "2.8.0"
+date-released: "2026-07-13"
 preferred-citation:
   type: dataset
   title: "GenAI & Agentic AI Security Incidents"
@@ -43,6 +43,6 @@ preferred-citation:
       given-names: "Emmanuel"
       alias: "emmanuelgjr"
   year: 2026
-  version: "2.7.0"
+  version: "2.8.0"
   doi: 10.5281/zenodo.20248676
   url: "https://doi.org/10.5281/zenodo.20248676"

--- a/INCIDENTS.md
+++ b/INCIDENTS.md
@@ -3,7 +3,7 @@
 Single source of truth for GenAI and agentic AI security incidents.
 Each entry is mapped to **OWASP LLM Top 10 (2025)**, **OWASP Agentic Top 10 (ASI)**, **NIST AI RMF**, and **MITRE ATLAS**.
 
-- **Version:** 2.7.0
+- **Version:** 2.8.0
 - **Generated:** 2026-07-12
 - **Total incidents:** **12,986**
 - **Date range:** 1983 – 2026

--- a/data/incidents.min.json
+++ b/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.0",
+  "version": "2.8.0",
   "generated": "2026-07-12",
   "incident_count": 12986,
   "incidents": [

--- a/data/stats.json
+++ b/data/stats.json
@@ -1,7 +1,7 @@
 {
   "incident_count": 12986,
   "landmark_count": 1865,
-  "version": "2.7.0",
+  "version": "2.8.0",
   "generated": "2026-07-12",
   "year_min": 1983,
   "year_max": 2026

--- a/docs/data/incidents.min.json
+++ b/docs/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.0",
+  "version": "2.8.0",
   "generated": "2026-07-12",
   "incident_count": 12986,
   "incidents": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "genai-incidents"
-version = "2.7.0"
+version = "2.8.0"
 description = "Curated dataset of GenAI & agentic-AI security incidents mapped to OWASP LLM Top 10, OWASP Agentic Top 10, NIST AI RMF, and MITRE ATLAS."
 readme = "README.md"
 license = "MIT"

--- a/scripts/merge_and_dedupe.py
+++ b/scripts/merge_and_dedupe.py
@@ -1551,7 +1551,7 @@ def main():
 
     # 9) Write outputs
     out = {
-        "version": "2.7.0",
+        "version": "2.8.0",
         "generated": generated,
         "description": (
             "Single source of truth for GenAI and agentic AI security incidents. "

--- a/src/genai_incidents/data/incidents.min.json
+++ b/src/genai_incidents/data/incidents.min.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.7.0",
+  "version": "2.8.0",
   "generated": "2026-07-12",
   "incident_count": 12986,
   "incidents": [


### PR DESCRIPTION
Version cut of the data-quality work since v2.7.0. **Version-string-only data diff** (12,986 / 0 added / 0 removed vs `main`).

### Included
- **#88/#95** — 25 non-GenAI scope-contamination buckets removed (dexidp/dex 708 CVEs, Juju 93, Magento ×11, KaiOS, Chrome, Jenkins ×4, Liferay, Mattermost, MantisBT, jackson-toml, Firefox). Net composition **12,770 → 12,986**; landmark **1,858 → 1,865**.
- **#91/#92** — 55 landmark `reversibility_class` / `discovery_method` labels.
- **#93** — weekly source refresh (+241).
- **#94** — `audit_cve_bridge.py` precision-audit tooling.

### Version sites bumped (5)
`pyproject.toml` · `scripts/merge_and_dedupe.py` `"version"` · `CITATION.cff` `version` + `preferred-citation.version` + `date-released` · CHANGELOG entry. Marketing "12,500+" unchanged (12,986 stays in the 12,5xx floor).

### Verification (python:3.12-bookworm)
2× byte-identical rebuild · `validate.py` clean (all deprecations resolve) · 152 tests pass.

Merges then `gh release create v2.8.0 --target main` → auto-publishes PyPI + Hugging Face; Zenodo mints the version DOI.
